### PR TITLE
feat: non-normative STS API spec

### DIFF
--- a/specifications/M1/identity-trust-sts-api.yaml
+++ b/specifications/M1/identity-trust-sts-api.yaml
@@ -1,0 +1,89 @@
+openapi: 3.0.1
+paths:
+  /token:
+    post:
+      operationId: token
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            encoding:
+              access_token:
+                style: form
+              audience:
+                style: form
+              bearer_access_alias:
+                style: form
+              bearer_access_scope:
+                style: form
+              client_id:
+                style: form
+              client_secret:
+                style: form
+              grant_type:
+                style: form
+            schema:
+              type: object
+              properties:
+                access_token:
+                  type: string
+                  description: VP access token to be added as a claim in the SI token
+                audience:
+                  type: string
+                  description: Audience for the SI token
+                bearer_access_alias:
+                  type: string
+                  description: Alias to be use in the sub of the VP access token (default
+                    is audience)
+                bearer_access_scope:
+                  type: string
+                  description: Scope to be added in the VP access token
+                client_id:
+                  type: string
+                  description: Id of the client requesting an SI token
+                client_secret:
+                  type: string
+                  description: Secret of the client requesting an SI token
+                grant_type:
+                  type: string
+                  description: "Type of grant: must be set to client_credentials"
+              required:
+              - audience
+              - client_id
+              - client_secret
+              - grant_type
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StsTokenResponse'
+          description: The Self-Issued ID token
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StsTokenErrorResponse'
+          description: Invalid Request
+      tags:
+      - Secure Token Service Api
+components:
+  schemas:
+    StsTokenErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+        error_description:
+          type: string
+    StsTokenResponse:
+      type: object
+      properties:
+        access_token:
+          type: string
+        expires_in:
+          type: integer
+          format: int64
+        token_type:
+          type: string

--- a/specifications/M1/identity.protocol.base.md
+++ b/specifications/M1/identity.protocol.base.md
@@ -114,6 +114,8 @@ An STS implementation MAY use endpoint parameters as defined by
 the [OAuth 2 specification](https://www.rfc-editor.org/rfc/rfc6749.html#section-8.2) to convey metadata necessary for the
 creation of the `access_token` claim.
 
+> A non-normative OpenAPI spec of an STS implementing client credentials flow is provided [here](./identity-trust-sts-api.yaml)
+
 # 7. The Identity and Trust Protocol Context
 
 The `Json-ld context` URI for the all identity and trust specifications is:


### PR DESCRIPTION
Adds a non-normative OpenAPI spec for an STS implementing client credentials flow