### PR TITLE
Add Json-Ld context, cleanup message types, add proper context URLs

### DIFF
--- a/specifications/M1/context.json
+++ b/specifications/M1/context.json
@@ -1,112 +1,116 @@
 {
-  "iatp": "https://w3id.org/tractusx-trust/v0.8/",
-  "cred": "https://www.w3.org/2018/credentials/",
-  "xsd": "http://www.w3.org/2001/XMLSchema/",
-  "CredentialContainer": {
-    "@id": "iatp:CredentialContainer",
-    "@context": {
-      "payload": {
-        "@id": "iatp:payload",
-        "@type": "xsd:string"
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "iatp": "https://w3id.org/tractusx-trust/v0.8/",
+    "cred": "https://www.w3.org/2018/credentials/",
+    "xsd": "http://www.w3.org/2001/XMLSchema/",
+    "CredentialContainer": {
+      "@id": "iatp:CredentialContainer",
+      "@context": {
+        "payload": {
+          "@id": "iatp:payload",
+          "@type": "xsd:string"
+        }
       }
-    }
-  },
-  "CredentialMessage": {
-    "@id": "iatp:CredentialMessage",
-    "@context": {
-      "credentials": "iatp:credentials"
-    }
-  },
-  "CredentialObject": {
-    "@id": "iatp:CredentialObject",
-    "@context": {
-      "credentialType": {
-        "@id": "iatp:credentialType",
-        "@container": "@set"
-      },
-      "format": "iatp:format",
-      "offerReason": {
-        "@id": "iatp:offerReason",
-        "@type": "xsd:string"
-      },
-      "bindingMethods": {
-        "@id": "iatp:bindingMethods",
-        "@type": "xsd:string",
-        "@container": "@set"
-      },
-      "cryptographicSuites": {
-        "@id": "iatp:cryptographicSuites",
-        "@type": "xsd:string",
-        "@container": "@set"
-      },
-      "issuancePolicy": "iatp:issuancePolicy"
-    }
-  },
-  "CredentialOfferMessage": {
-    "@id": "iatp:CredentialOfferMessage",
-    "@context": {
-      "credentialIssuer": "cred:issuer",
-      "credentials": "iatp:credentials"
-    }
-  },
-  "CredentialRequestMessage": {
-    "@id": "iatp:CredentialRequestMessage",
-    "@context": {
-      "format": "iatp:format",
-      "type": "@type"
-    }
-  },
-  "CredentialService": "iatp:CredentialService",
-  "CredentialStatus": {
-    "@id": "iatp:CredentialStatus",
-    "@context": {
-      "requestId":{
-        "@id": "iatp:requestId",
-        "@type": "@id"
-      },
-      "status": {
-        "@id": "iatp:status",
-        "@type": "xsd:string"
+    },
+    "CredentialMessage": {
+      "@id": "iatp:CredentialMessage",
+      "@context": {
+        "credentials": "iatp:credentials"
       }
-    }
-  },
-  "IssuerMetadata": {
-    "@id": "iatp:IssuerMetadata",
-    "@context": {
-      "credentialIssuer": "cred:issuer",
-      "credentialsSupported": {
-        "@id": "iatp:credentialsSupported",
-        "@container": "@set"
+    },
+    "CredentialObject": {
+      "@id": "iatp:CredentialObject",
+      "@context": {
+        "credentialType": {
+          "@id": "iatp:credentialType",
+          "@container": "@set"
+        },
+        "format": "iatp:format",
+        "offerReason": {
+          "@id": "iatp:offerReason",
+          "@type": "xsd:string"
+        },
+        "bindingMethods": {
+          "@id": "iatp:bindingMethods",
+          "@type": "xsd:string",
+          "@container": "@set"
+        },
+        "cryptographicSuites": {
+          "@id": "iatp:cryptographicSuites",
+          "@type": "xsd:string",
+          "@container": "@set"
+        },
+        "issuancePolicy": "iatp:issuancePolicy"
       }
-    }
-  },
-  "PresentationQueryMessage": {
-    "@id": "iatp:PresentationQueryMessage",
-    "@context": {
-      "presentationDefinition": "iatp:presentationDefinition",
-      "scope": "iatp:scope"
-    }
-  },
-  "credentials": {
-    "@id": "iatp:credentials",
-    "@container": "@set"
-  },
-  "credentialSubject": {
-    "@id": "iatp:credentialSubject",
-    "@type": "cred:credentialSubject"
-  },
-  "format": {
-    "@id": "iatp:format",
-    "@type": "xsd:string"
-  },
-  "presentationDefinition": {
-    "@id": "iatp:presentationDefinition",
-    "@type": "@json"
-  },
-  "scope": {
-    "@id": "iatp:scope",
-    "@type": "xsd:string",
-    "@container": "@set"
-  },
-  "type": "@type"
+    },
+    "CredentialOfferMessage": {
+      "@id": "iatp:CredentialOfferMessage",
+      "@context": {
+        "credentialIssuer": "cred:issuer",
+        "credentials": "iatp:credentials"
+      }
+    },
+    "CredentialRequestMessage": {
+      "@id": "iatp:CredentialRequestMessage",
+      "@context": {
+        "format": "iatp:format",
+        "type": "@type"
+      }
+    },
+    "CredentialService": "iatp:CredentialService",
+    "CredentialStatus": {
+      "@id": "iatp:CredentialStatus",
+      "@context": {
+        "requestId": {
+          "@id": "iatp:requestId",
+          "@type": "@id"
+        },
+        "status": {
+          "@id": "iatp:status",
+          "@type": "xsd:string"
+        }
+      }
+    },
+    "IssuerMetadata": {
+      "@id": "iatp:IssuerMetadata",
+      "@context": {
+        "credentialIssuer": "cred:issuer",
+        "credentialsSupported": {
+          "@id": "iatp:credentialsSupported",
+          "@container": "@set"
+        }
+      }
+    },
+    "PresentationQueryMessage": {
+      "@id": "iatp:PresentationQueryMessage",
+      "@context": {
+        "presentationDefinition": "iatp:presentationDefinition",
+        "scope": "iatp:scope"
+      }
+    },
+    "credentials": {
+      "@id": "iatp:credentials",
+      "@container": "@set"
+    },
+    "credentialSubject": {
+      "@id": "iatp:credentialSubject",
+      "@type": "cred:credentialSubject"
+    },
+    "format": {
+      "@id": "iatp:format",
+      "@type": "xsd:string"
+    },
+    "presentationDefinition": {
+      "@id": "iatp:presentationDefinition",
+      "@type": "@json"
+    },
+    "scope": {
+      "@id": "iatp:scope",
+      "@type": "xsd:string",
+      "@container": "@set"
+    },
+    "type": "@type"
+  }
 }

--- a/specifications/M1/context.json
+++ b/specifications/M1/context.json
@@ -1,0 +1,112 @@
+{
+  "iatp": "https://w3id.org/tractusx-trust/v0.8/",
+  "cred": "https://www.w3.org/2018/credentials/",
+  "xsd": "http://www.w3.org/2001/XMLSchema/",
+  "CredentialContainer": {
+    "@id": "iatp:CredentialContainer",
+    "@context": {
+      "payload": {
+        "@id": "iatp:payload",
+        "@type": "xsd:string"
+      }
+    }
+  },
+  "CredentialMessage": {
+    "@id": "iatp:CredentialMessage",
+    "@context": {
+      "credentials": "iatp:credentials"
+    }
+  },
+  "CredentialObject": {
+    "@id": "iatp:CredentialObject",
+    "@context": {
+      "credentialType": {
+        "@id": "iatp:credentialType",
+        "@container": "@set"
+      },
+      "format": "iatp:format",
+      "offerReason": {
+        "@id": "iatp:offerReason",
+        "@type": "xsd:string"
+      },
+      "bindingMethods": {
+        "@id": "iatp:bindingMethods",
+        "@type": "xsd:string",
+        "@container": "@set"
+      },
+      "cryptographicSuites": {
+        "@id": "iatp:cryptographicSuites",
+        "@type": "xsd:string",
+        "@container": "@set"
+      },
+      "issuancePolicy": "iatp:issuancePolicy"
+    }
+  },
+  "CredentialOfferMessage": {
+    "@id": "iatp:CredentialOfferMessage",
+    "@context": {
+      "credentialIssuer": "cred:issuer",
+      "credentials": "iatp:credentials"
+    }
+  },
+  "CredentialRequestMessage": {
+    "@id": "iatp:CredentialRequestMessage",
+    "@context": {
+      "format": "iatp:format",
+      "type": "@type"
+    }
+  },
+  "CredentialService": "iatp:CredentialService",
+  "CredentialStatus": {
+    "@id": "iatp:CredentialStatus",
+    "@context": {
+      "requestId":{
+        "@id": "iatp:requestId",
+        "@type": "@id"
+      },
+      "status": {
+        "@id": "iatp:status",
+        "@type": "xsd:string"
+      }
+    }
+  },
+  "IssuerMetadata": {
+    "@id": "iatp:IssuerMetadata",
+    "@context": {
+      "credentialIssuer": "cred:issuer",
+      "credentialsSupported": {
+        "@id": "iatp:credentialsSupported",
+        "@container": "@set"
+      }
+    }
+  },
+  "PresentationQueryMessage": {
+    "@id": "iatp:PresentationQueryMessage",
+    "@context": {
+      "presentationDefinition": "iatp:presentationDefinition",
+      "scope": "iatp:scope"
+    }
+  },
+  "credentials": {
+    "@id": "iatp:credentials",
+    "@container": "@set"
+  },
+  "credentialSubject": {
+    "@id": "iatp:credentialSubject",
+    "@type": "cred:credentialSubject"
+  },
+  "format": {
+    "@id": "iatp:format",
+    "@type": "xsd:string"
+  },
+  "presentationDefinition": {
+    "@id": "iatp:presentationDefinition",
+    "@type": "@json"
+  },
+  "scope": {
+    "@id": "iatp:scope",
+    "@type": "xsd:string",
+    "@container": "@set"
+  },
+  "type": "@type"
+}

--- a/specifications/M1/verifiable.presentation.protocol.md
+++ b/specifications/M1/verifiable.presentation.protocol.md
@@ -136,7 +136,7 @@ The POST body is a `CredentialMessage` JSON object with the following properties
 A `PresentationQueryMessage` MUST contain either a `presentationDefinition` or a `scope` parameter. It is an error to
 contain both.
 
-The following is a non-normative example of the JSON body:
+The following are non-normative examples of the JSON body:
 
 ```json
 {
@@ -145,8 +145,18 @@ The following is a non-normative example of the JSON body:
     "https://identity.foundation/presentation-exchange/submission/v1"
   ],
   "@type": "PresentationQueryMessage",
-  "presentationDefinition": "...",
   "scope": []
+}
+```
+
+```json
+{
+  "@context": [
+    "https://w3id.org/catenax/2023/cs/v1",
+    "https://identity.foundation/presentation-exchange/submission/v1"
+  ],
+  "@type": "PresentationQueryMessage",
+  "presentationDefinition": "..."
 }
 ```
 


### PR DESCRIPTION
This PR adds the IATP Json-Ld context, cleans up missing message type information, and fixes incorrect context URLs. Specifically:

- Introduces a Json-Ld context that can be (optionally) used for runtimes to perform Json-Ld expansion and basic validation
- Renames the `types` attribute to `type` on `CredentialRequestMessage` so it is consistent throughout all documents and with W3C standards
- Replaces inconsistent property naming where `_` was used instead of Camel Case (e.g. `presentationDefinition` instead of `presentation_definition`
- Renames `types` to `credentialTypes` on `IssuerMetadata` since renaming it to`type` would clash with the ODRL definition of `type` as `@type`, which would cause Json-Ld expansion to add the value to the `IssuerMetadata` @type property.
-  Uses `iatp` as a prefix for consistency
- Uses the URL `https://w3id.org/tractusx-trust/v0.8` for consistency

**_Please use GitHub's suggestions feature when making comments so proposed modifications can be directly committed._** 

# Linked Issues
Closes #31
