### PR TITLE
chore: Update docs with respect to the state of the repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,33 +14,45 @@ where these companies will be able to participate quickly and with little IT
 infrastructure investment. Tractus-X is meant to be the PoC project of the
 Catena-X alliance focusing on parts traceability.
 
-* <https://projects.eclipse.org/projects/automotive.tractusx>
+* https://projects.eclipse.org/projects/automotive.tractusx
+
+## Project licenses
+
+This Tractus-X project repository uses the following license:
+
+* CC-BY-4.0 for non-code
+
+## Terms of Use
+
+This repository is subject to the Terms of Use of the Eclipse Foundation
+
+* https://www.eclipse.org/legal/termsofuse.php
 
 ## Developer resources
 
 Information regarding source code management, builds, coding standards, and
 more.
 
-* <https://projects.eclipse.org/projects/automotive.tractusx/developer>
+* https://projects.eclipse.org/projects/automotive.tractusx/developer
 
 The project maintains the source code repositories in the following GitHub organization:
 
-* <https://github.com/eclipse-tractusx/>
+* https://github.com/eclipse-tractusx
 
 ## Eclipse Development Process
 
 This Eclipse Foundation open project is governed by the Eclipse Foundation
 Development Process and operates under the terms of the Eclipse IP Policy.
 
-* <https://eclipse.org/projects/dev_process>
-* <https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf>
+* https://eclipse.org/projects/dev_process
+* https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf
 
 ## Eclipse Contributor Agreement
 
 In order to be able to contribute to Eclipse Foundation projects you must
 electronically sign the Eclipse Contributor Agreement (ECA).
 
-* <http://www.eclipse.org/legal/ECA.php>
+* http://www.eclipse.org/legal/ECA.php
 
 The ECA provides the Eclipse Foundation with a permanent record that you agree
 that each of your contributions will comply with the commitments documented in
@@ -49,10 +61,10 @@ the email address matching the "Author" field of your contribution's Git commits
 fulfills the DCO's requirement that you sign-off on your contributions.
 
 For more information, please see the Eclipse Committer Handbook:
-<https://www.eclipse.org/projects/handbook/#resources-commit>
+https://www.eclipse.org/projects/handbook/#resources-commit
 
 ## Contact
 
 Contact the project developers via the project's "dev" list.
 
-* <https://accounts.eclipse.org/mailing-list/tractusx-dev>
+* https://accounts.eclipse.org/mailing-list/tractusx-dev

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -18,18 +18,20 @@ source code repository logs.
 
 ## Declared Project Licenses
 
-The materials in this repository is made available under the terms
-of the Creative Commons Attribution 4.0 International License, which is available at
-https://spdx.org/licenses/CC-BY-4.0.html.
+This Tractus-X project repository uses the following license:
 
+- CC-BY-4.0 for non-code
+
+CC-BY-4.0:
+The materials in this repository are made available under the terms of the Creative Commons Attribution 4.0 International License, which is available at https://spdx.org/licenses/CC-BY-4.0.html.
 SPDX-License-Identifier: CC-BY-4.0
 
 ## Source Code
 
 The project maintains the following source code repositories
-in the GitHub organization <https://github.com/eclipse-tractusx>:
+in the GitHub organization https://github.com/eclipse-tractusx:
 
-* <https://github.com/eclipse-tractusx/identity-trust>
+* https://github.com/eclipse-tractusx/identity-trust
 
 ## Third-party Content
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,13 @@
 This repository contains normative documents defining protocols and flows withing the Identity and Trust system to be
 used in Tractus-X projects.
 
+The responsibility of the specification has been transfered to the [Eclipse Dataspace Working Group](https://dataspace.eclipse.org).
+Please file change requests or contributions according to the working group processes.
+
+Until the first version of the specification from the working group is released and implemented, this repository contains the
+current specification implemented in the Catena-X data space. Maintenance is limited to urgent issues concerning the
+operation of this data space.
+
 There are [designated editors](./pr_etiquette.md#the-designated-editors-as-of-sept-21-2023), who are the primary
-contributors to the content of this repository. Please file all change-requests through GitHub Discussions or Issues.
-
-For any contributions beyond that, please notice our [PR etiquette](pr_etiquette.md).
-
-
+contributors to the content of this repository. Please file urgent issues that cannot wait for the first working
+group release through GitHub Discussions or Issues.


### PR DESCRIPTION
## WHAT

Changes the license file and other legal references according to the requirements from TRG 7 with deviations due to the special character of the project.

## WHY

Because of a recent change to the requirements in the TRG and the fact, that the content responsibility has been transferred to the Eclipse Dataspace Working Group.

Closes #54 