### PR TITLE
feat: add respec pipeline

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,0 +1,34 @@
+name: Bug Report
+description: Create a report to advance maturity of the spec!
+labels: ["bug", "triage"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What's wrong?
+      placeholder: Reasons could be contradictions (internally or to external standards), ambiguities, wrong schema files, writing
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this a bug?
+      description: Also tell us, what did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: how
+    attributes:
+      label: How could it be fixed?
+      description: Feel free to suggest and weigh several resolution strategies. Omit if obvious.
+  - type: textarea
+    id: context
+    attributes:
+      label: More context
+      description: If applicable, add additional info to help explain your problem.
+  - type: markdown
+    attributes:
+      value: |
+        _Please be sure to take a look at
+        our [contribution guidelines](https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/blob/main/CONTRIBUTING.md) and
+        our [PR etiquette](https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/blob/main/PR_ETIQUETTE.md)._

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,34 @@
+name: Feature Request Report
+description: Tell us about your idea and request a new feature
+labels: ["enhancement", "triage"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What's missing?
+      placeholder: Describe what the spec should govern but currently doesn't
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why should it be in the spec?
+      description: Explain why this is an issue for DCP specifically. Reasons might be to eliminate ambiguity or take new functionality into scope.
+    validations:
+      required: true
+  - type: textarea
+    id: where
+    attributes:
+      label: Where should this be added?
+      description: What location in the existing structure could be extended to accommodate the proposed feature?
+  - type: textarea
+    id: context
+    attributes:
+      label: More context
+      description: If applicable, add additional info to help explain your problem.
+  - type: markdown
+    attributes:
+      value: |
+        _Please be sure to take a look at
+        our [contribution guidelines](https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/blob/main/CONTRIBUTING.md) and
+        our [PR etiquette](https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/blob/main/PR_ETIQUETTE.md)._

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## WHAT
+
+_Briefly describe what your PR changes, which features it adds/modifies._
+
+Closes # <-- _insert Issue number if one exists_
+
+## How was the issue fixed?
+
+_Briefly state why the change was necessary._
+
+## More context
+
+_List other areas that have changed but are not necessarily linked to the main feature. This could be naming changes, 
+bugs that were encountered and were fixed inline, etc._

--- a/.github/workflows/autopublish.yaml
+++ b/.github/workflows/autopublish.yaml
@@ -1,0 +1,30 @@
+name: Auto-Publish
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    name: Build and Validate
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: w3c/spec-prod@v2
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/autopublish.yaml
+++ b/.github/workflows/autopublish.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
 jobs:
   build:
     name: Build and Validate

--- a/.github/workflows/build-only.yaml
+++ b/.github/workflows/build-only.yaml
@@ -1,0 +1,14 @@
+name: Build Only
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    name: Build and Validate
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: w3c/spec-prod@v2

--- a/.github/workflows/build-only.yaml
+++ b/.github/workflows/build-only.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 jobs:
   build:
     name: Build and Validate

--- a/index.html
+++ b/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset='utf-8'>
+	<script src='https://www.w3.org/Tools/respec/respec-w3c' async class='remove'></script>
+	<script class='remove'>
+		var respecConfig = {
+		  specStatus: "unofficial",
+		  editors: [{
+			  name: "Your Name",
+			  url: "https://your-site.com",
+			  company: "My company",
+			  companyURL: "https://your-site.com",
+		  }],
+		  github: {
+			branch: "main",
+			repoURL: "eclipse-dataspace-dcp/decentralized-claims-protocol",
+		  },
+		  xref: "web-platform",
+		};
+	</script>
+</head>
+<body>
+<h1 id="title">Eclipse Decentralized Claims Protocol</h1>
+<section id='abstract'>
+	<p>
+		This is the abstract (required).
+	</p>
+</section>
+<section id='sotd'>
+	<p>
+		This is the state of the doc.
+	</p>
+</section>
+<section>
+	<h2>Introduction</h2>
+	<section>
+		<h3>
+			Automated bibliography management
+		</h3>
+		<p>
+			This section has a CSS class "<code>informative</code>", so it is
+			listed in the TOC. ReSpec will list this reference as non-normative
+			since this is an informative section [[HTML]].
+		</p>
+	</section>
+	<section>
+		<h3>
+			Rendering of HTTP requests etc
+		</h3>
+		<aside class="example" title="Some payload">
+			<p>
+				A http request from the spec
+			<p>
+			<pre class="http">
+POST /credentials HTTP/1.1
+Host: server.example.com
+Content-Type: application/json
+Authorization: Bearer ......
+
+{
+   "a": "b",
+   "foo": bar
+}
+  </pre>
+		</aside>
+	</section>
+	<h3>
+		Embedding of Figures
+	</h3>
+	<p>There's no automatic diagram rendering like the mermaid code block in Github markdown. That's not necessarily
+		a problem as we can use exports</p>
+	<figure id="issuance-flow">
+		<img src="static/issuance.flow.png" alt="Hard to describe tbh..."/>
+		<figcaption>The issuance flow is basically the auth flow with a different scope in the SI token 🤷🏻‍♂️
+		</figcaption>
+	</figure>
+</section>
+<section id='conformance'>
+	<!-- This section is filled automatically by ReSpec. -->
+</section>
+<section id="tof" class="appendix"></section>
+
+
+</body>
+</html>


### PR DESCRIPTION
PR will stay in draft mode until a committer has enabled github pages with source "github actions".

closes #2 