### PR TITLE
feat: add automatic html build via respec

### DIFF
--- a/.github/workflows/autopublish.yaml
+++ b/.github/workflows/autopublish.yaml
@@ -1,0 +1,43 @@
+name: Auto-Publish
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and Validate
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - name: Inject md to html
+        run: |
+          chmod +x ./scripts/replace.sh
+          ./scripts/replace.sh
+      - name: Run Respec
+        run:
+          sudo npx puppeteer browsers install chrome
+          npx respec --src index.html --out index.html.build.html -t 60 --disable-sandbox --verbose
+#      - uses: w3c/spec-prod@v2
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+index.html

--- a/scripts/replace.sh
+++ b/scripts/replace.sh
@@ -1,0 +1,15 @@
+cp scripts/respec-template.html index.html
+index=`cat index.html`
+top=`cat specifications/tx.dataspace.topology.md`
+topph="THIS IS THE PLACEHOLDER FOR THE DATASPACE TOPOLOGY"
+base=`cat specifications/identity.protocol.base.md`
+baseph="THIS IS THE PLACEHOLDER FOR THE BASE PROTOCOL"
+pres=`cat specifications/verifiable.presentation.protocol.md`
+presph="THIS IS THE PLACEHOLDER FOR THE PRESENTATION PROTOCOL"
+iss=`cat specifications/credential.issuance.protocol.md`
+issph="THIS IS THE PLACEHOLDER FOR THE ISSUANCE PROTOCOL"
+index="${index/$topph/"$top"}"
+index="${index/$baseph/"$base"}"
+index="${index/$presph/"$pres"}"
+index="${index/$issph/"$iss"}"
+echo "$index" > index.html

--- a/scripts/respec-template.html
+++ b/scripts/respec-template.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+    <meta charset='utf-8'>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c' async class='remove'></script>
+    <script class='remove'>
+        var respecConfig = {
+          specStatus: "unofficial",
+          editors: [{
+              name: "Your Name",
+              url: "https://your-site.com",
+              company: "My company",
+              companyURL: "https://your-site.com",
+          }],
+          github: {
+            branch: "main",
+            repoURL: "eclipse-dataspace-dcp/decentralized-claims-protocol",
+          },
+          xref: "web-platform",
+          lint: { "no-unused-dfns": false },
+          format: "markdown"
+        };
+    </script>
+    <title>Eclipse Decentralized Claims Protocol</title>
+</head>
+<body>
+<p class="copyright">
+    This document is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">The Apache License, Version 2.0</a>.
+</p>
+<h1 id="title">Eclipse Decentralized Claims Protocol</h1>
+<section id='abstract'>
+    <p>
+        This repository contains normative documents defining protocols and flows withing the Identity and Trust system
+        to be used in Tractus-X projects.
+    </p>
+</section>
+<section id='sotd'>
+    <p>
+        The responsibility of the specification has been transfered to the <a href="https://dataspace.eclipse.org/">Eclipse
+        Dataspace Working Group</a>.
+        Please file
+        change requests or contributions according to the working group processes. Until the first version of the
+        specification from the working group is released and implemented, this repository contains the current
+        specification implemented in the Catena-X data space. Maintenance is limited to urgent issues concerning the
+        operation of this data space. There are <a
+            href="https://github.com/eclipse-tractusx/identity-trust/blob/main/pr_etiquette.md#the-designated-editors-as-of-sept-21-2023">designated
+        editors</a>,
+        who are the primary contributors to the content of
+        this repository. Please file urgent issues that cannot wait for the first working group release through GitHub
+        Discussions or Issues.
+    </p>
+</section>
+<section>
+
+THIS IS THE PLACEHOLDER FOR THE DATASPACE TOPOLOGY
+
+</section>
+<section>
+
+THIS IS THE PLACEHOLDER FOR THE BASE PROTOCOL
+
+</section>
+
+<section>
+
+THIS IS THE PLACEHOLDER FOR THE PRESENTATION PROTOCOL
+
+</section>
+
+<section>
+
+THIS IS THE PLACEHOLDER FOR THE ISSUANCE PROTOCOL
+
+</section>
+<section id='conformance'></section>
+<section id="tof" class="appendix">
+    <h1>Notes</h1>
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
## WHAT

The DCP needs a proper representation as webpage. Respec is an established tool for this. 

Closes #67

## How was the issue fixed?

To preserve the commit history, the existing markdown structure is loaded into a template via github workflow and transformed into html by existing respec tooling.

## More context

This PR will result in a webpage including duplicate section numbering, broken links. This will be fixed in a subsequent PR.