### PR TITLE
fix: typos in credential.issuance.protocol.md

### DIFF
--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -72,7 +72,7 @@ The ID Token MUST contain a `token` claim that is a bearer token granting write 
 requested VCs into the client's `Credential Service` as defined by
 [[[#verifiable-presentation-protocol]]]
 
-The ID Token MAY contain an `token` claim as defined in
+The ID Token MAY contain a `token` claim as defined in
 [[[#identity-protocol-base]]] claim that can be used by the issuer to resolve
 Verifiable Presentations (VP) the client is required to hold for issuance of the requested VCs.
 
@@ -154,7 +154,7 @@ The Credential Offer `POST` body MUST be a `CredentialOfferMessage` JSON object 
 The following is a non-normative example of a credential offer request:
 
 ```
-POST /credentials HTTP/1.1
+POST /offers HTTP/1.1
 Host: server.example.com
 Content-Type: application/json
 Authorization: Bearer ......
@@ -293,7 +293,7 @@ The following is a non-normative example of a `IssuerMetadata` response object:
 
 The issuer MUST provide an `HTTPS GET` endpoint for retrieving the status of a credential at the base issuer url with
 the appended path `/requests/<request id>`. The issuer SHOULD implement access control such that only the client that
-made the request may access a particualr request status.
+made the request may access a particular request status.
 
 If accepted, a `CredentialStatus` Json object with a `status` property set to one of the following
 values: `RECEIVED` | `REJECTED` | `ISSUED` will be returned.


### PR DESCRIPTION
## WHAT

Typos in the credential.issuance.protocol.md file.

## How was the issue fixed?

Typos were fixed and one endpoint in an example request did not match the textual explanation beforehand, therefore I changed `/credentials` to `/offers`.

## More context