### PR TITLE
chores: remove tractus-x reference in README, pr_etiquette and specification'…

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,6 +1,0 @@
-product: "Identity And Trust Specifications"
-leadingRepository: "https://github.com/eclipse-tractusx/identity-trust"
-repositories:
-- name: "identity trust"
-  usage: "Identity And Trust Specification"
-  url: "https://github.com/eclipse-tractusx/identity-trust"

--- a/LICENSE
+++ b/LICENSE
@@ -1,104 +1,176 @@
-Creative Commons Attribution 4.0 International
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-Creative Commons Corporation ("Creative Commons") is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an "as-is" basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Using Creative Commons Public Licenses
+1. Definitions.
 
-Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
 
-Considerations for licensors: Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. More considerations for licensors : wiki.creativecommons.org/Considerations_for_licensors
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
 
-Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor's permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public : wiki.creativecommons.org/Considerations_for_licensees
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
 
-Creative Commons Attribution 4.0 International Public License
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
 
-By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
 
-Section 1 – Definitions.
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
 
-a. Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
-b. Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
-c. Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
-d. Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
-e. Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
-f. Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
-g. Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
-h. Licensor means the individual(s) or entity(ies) granting rights under this Public License.
-i. Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
-j. Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
-k. You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
 
-Section 2 – Scope.
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
 
-a. License grant.
-1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
-A. reproduce and Share the Licensed Material, in whole or in part; and
-B. produce, reproduce, and Share Adapted Material.
-2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
-3. Term. The term of this Public License is specified in Section 6(a).
-4. Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
-5. Downstream recipients.
-A. Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
-B. No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
-6. No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
-b. Other rights.
-1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
-2. Patent and trademark rights are not licensed under this Public License.
-3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
 
-Section 3 – License Conditions.
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
 
-Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
 
-a. Attribution.
-1. If You Share the Licensed Material (including in modified form), You must:
-A. retain the following if it is supplied by the Licensor with the Licensed Material:
-i. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
-ii. a copyright notice;
-iii. a notice that refers to this Public License;
-iv. a notice that refers to the disclaimer of warranties;
-v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
-B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
-C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
-2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
-3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
-4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
 
-Section 4 – Sui Generis Database Rights.
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
 
-Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
 
-a. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
-b. if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
-c. You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
-For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
 
-Section 5 – Disclaimer of Warranties and Limitation of Liability.
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
 
-a. Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
-b. To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
-c. The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
-Section 6 – Term and Termination.
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
 
-a. This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
-b. Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
-1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
-2. upon express reinstatement by the Licensor.
-c. For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
-d. For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
-e. Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
 
-Section 7 – Other Terms and Conditions.
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
 
-a. The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
-b. Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
 
-ection 8 – Interpretation.
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
 
-a. For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
-b. To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
-c. No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
-d. Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
-Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the "Licensor." The text of the Creative Commons public licenses is dedicated to the public domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark "Creative Commons" or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
 
-Creative Commons may be contacted at creativecommons.org.
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
-# Identity And Trust Specifications
+# Decentralized Claims Protocol DCP
 
-This repository contains normative documents defining protocols and flows withing the Identity and Trust system to be
-used in Tractus-X projects.
+This repository contains normative documents defining protocols and flows of the Eclipse Decentralized Claims Protocol (DCP) defines an interoperable overlay to the [Dataspace Protocol (DSP)](https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol) Specifications for conveying organizational identities and establishing trust in a way that preserves privacy and limits the possibility of network disruption.
 
-The responsibility of the specification has been transfered to the [Eclipse Dataspace Working Group](https://dataspace.eclipse.org).
-Please file change requests or contributions according to the working group processes.
+The scope of Eclipse DCP specification includes:
 
-Until the first version of the specification from the working group is released and implemented, this repository contains the
-current specification implemented in the Catena-X data space. Maintenance is limited to urgent issues concerning the
-operation of this data space.
+- Specifying a format for self-issued identity tokens
+- Defining a protocol for storing and presenting Verifiable Credentials and other identity-related resources
+- Defining a protocol for parties to request credentials from a credential issuer
 
-There are [designated editors](./pr_etiquette.md#the-designated-editors-as-of-sept-21-2023), who are the primary
-contributors to the content of this repository. Please file urgent issues that cannot wait for the first working
-group release through GitHub Discussions or Issues.
+Eclipse DCP supports multiple trust anchors and allow participants to manage and verify presentations without needing third-party systems outside their control. Note that it is not a requirement for Eclipse DCP to specify a decentralized or "self-sovereign" identity protocol, but it may be based on it.

--- a/pr_etiquette.md
+++ b/pr_etiquette.md
@@ -59,8 +59,6 @@ Submitting pull requests in EDC should be done while adhering to a couple of sim
 
 - Jim Marino (@jimmarino)
 
-## Responsible committers (as of Feb 26, 2024)
+## Responsible committers 
 
-- Paul Latzelsperger (@paullatzelsperger)
-- Enrico Risa (@wolf4ood)
-- Jim Marino (@jimmarino)
+[Who's involved](https://projects.eclipse.org/projects/technology.dataspace-dcp/who)

--- a/specifications/context.json
+++ b/specifications/context.json
@@ -2,7 +2,7 @@
   "@context": {
     "@version": 1.1,
     "@protected": true,
-    "iatp": "https://w3id.org/tractusx-trust/v0.8/",
+    "iatp": "https://w3id.org/dspace-dcp/v0.8/",
     "cred": "https://www.w3.org/2018/credentials/",
     "xsd": "http://www.w3.org/2001/XMLSchema/",
     "CredentialContainer": {

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -101,7 +101,7 @@ Authorization: Bearer ......
 
 {
    "@context": [
-    "https://w3id.org/tractusx-trust/v0.8",
+    "https://w3id.org/dspace-dcp/v0.8",
      "https://www.w3.org/2018/credentials/v1"
    ],
    "@type": "CredentialRequestMessage",
@@ -161,7 +161,7 @@ Authorization: Bearer ......
 
 {
    "@context": [
-    "https://w3id.org/tractusx-trust/v0.8",
+    "https://w3id.org/dspace-dcp/v0.8",
      "https://www.w3.org/2018/credentials/v1"
    ],
    "@type": "CredentialOfferMessage",
@@ -197,7 +197,7 @@ The following is a non-normative example of a `CredentialObject`:
 ```json
 {
   "@context": {
-    "iatp": "https://w3id.org/tractusx-trust/v0.8",
+    "iatp": "https://w3id.org/dspace-dcp/v0.8",
     "odrl": "https://www.w3.org/ns/odrl.jsonld"
   },
   "@type": "CredentialObject",
@@ -250,7 +250,7 @@ The following is a non-normative example of a `IssuerMetadata` response object:
 ```json
 {
   "@context": {
-    "iatp": "https://w3id.org/tractusx-trust/v0.8",
+    "iatp": "https://w3id.org/dspace-dcp/v0.8",
     "odrl": "https://www.w3.org/ns/odrl.jsonld"
   },
   "@type": "IssuerMetadata",
@@ -310,7 +310,7 @@ The following is a non-normative example of a `CredentialStatus` response object
 ```json
 {
   "@context": {
-    "iatp": "https://w3id.org/tractusx-trust/v0.8"
+    "iatp": "https://w3id.org/dspace-dcp/v0.8"
   },
   "@type": "CredentialStatus",
   "requestId": "...",

--- a/specifications/dataspace.topology.md
+++ b/specifications/dataspace.topology.md
@@ -2,18 +2,15 @@
 
 ## Introduction
 
-This document details the systems topology that Tractus-X dataspaces employ. This topology adheres to the model defined
-by the Dataspace Protocol [[dsp-base]]:
+This topology adheres to the model defined by the Dataspace Protocol [[dsp-base]]:
 
-- The **Dataspace Authority** manages the dataspace. In a Tractus-X dataspace, this role may be federated across
+- The **Dataspace Authority** manages the dataspace. This role may be federated across
   multiple operating companies responsible for registration, onboarding, and operations management.
-- A **Participant** is a member the dataspace. In a Tractus-X dataspace, members may take on different roles, which are
+- A **Participant** is a member the dataspace. Members may take on different roles, which are
   attested to by **Verifiable Credentials**.
 - A **Participant Agent** performs tasks such as publishing a catalog or engaging in an asset transfer. Note that a
   participant agent is a logical construct and does not necessarily correspond to a single runtime process.
-- An **Identity Provider** is a service that generates ID tokens used to verify the identity of a Participant Agent. In
-  a Tractus-X dataspace, each participant will use their own identity provider, which may be self-hosted or hosted in a
-  managed environment.
+- An **Identity Provider** is a service that generates ID tokens used to verify the identity of a Participant Agent. Each participant will use their own identity provider, which may be self-hosted or hosted in a managed environment.
 - A **Credential Issuer** issues Verifiable Credentials (VC) used by participant agents to allow access to assets and
   verify usage control.
 

--- a/specifications/identity.protocol.base.md
+++ b/specifications/identity.protocol.base.md
@@ -2,13 +2,13 @@
 
 ## Introduction
 
-This document defines a base protocol for communicating participant identities and claims in a Tractus-X dataspace. This
-specification assumes familiarity with the [Tractus-X Dataspace Topology Specification](tx.dataspace.topology.md).
+This document defines a base protocol for communicating participant identities and claims in a dataspace. This
+specification assumes familiarity with the [Dataspace Topology Specification](dataspace.topology.md).
 
 ## Motivation
 
 The key goal of this protocol specification is to minimize the risk of business disruption related to the failure of
-identity and credential systems in a Tractus-X dataspace. As such, it provides a design for a decentralized system to
+identity and credential systems in a dataspace. As such, it provides a design for a decentralized system to
 communicate participant identities and [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) (VCs).
 
 > Note that it is not a design goal of this protocol to support a self-sovereign data exchange network where each

--- a/specifications/identity.protocol.base.md
+++ b/specifications/identity.protocol.base.md
@@ -120,9 +120,9 @@ present, the `token` claim MUST not be included.
 
 The [[[json-ld11]]] context URI for the all identity and trust specifications is:
 
-`https://w3id.org/tractusx-trust/v[version]`
+`https://w3id.org/dspace-dcp/v[version]`
 
 Where version indicates a [Semantic Versioning](https://semver.org/) `MAJOR.MINOR` number. The current specifications
 use `0.8` version and the following context URI:
 
-`https://w3id.org/tractusx-trust/v0.8`
+`https://w3id.org/dspace-dcp/v0.8`

--- a/specifications/testing/base_tests.md
+++ b/specifications/testing/base_tests.md
@@ -31,7 +31,7 @@ Where applicable, this document also provides test vectors in the form of `*.jso
 ## Definition of terms
 
 For the purposes of this document, term definitions from
-the [IATP specifications](http://github.com/eclipse-tractusx/identity-trust) apply, unless stated otherwise. In
+the [specifications](https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol) apply, unless stated otherwise. In
 addition, the following terms apply:
 
 - proving party: the party that makes certain claims about themselves

--- a/specifications/testing/sample_input_verification/v-t_0001_valid_vc_linked_proof.json
+++ b/specifications/testing/sample_input_verification/v-t_0001_valid_vc_linked_proof.json
@@ -3,9 +3,9 @@
     "credentialSubject": {
       "bpn": "BPNL000000000000",
       "id": "did:web:localhost:BPNL000000000000",
-      "type": "https://org.eclipse.tractusx/businessPartnerData#BpnCredential"
+      "type": "https://org.eclipse.placeholder/businessPartnerData#BpnCredential"
     },
-    "id": "https://org.eclipse.tractusx/testcases/t0001",
+    "id": "https://org.eclipse.placeholder/testcases/t0001",
     "type": [
       "VerifiableCredential",
       "BpnCredential"
@@ -16,7 +16,7 @@
       "type": "JsonWebSignature2020",
       "created": "2022-12-31T23:00:00Z",
       "proofPurpose": "assertionMethod",
-      "verificationMethod": "https://org.eclipse.tractusx/verification-method",
+      "verificationMethod": "https://org.eclipse.placeholder/verification-method",
       "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzM4NCJ9..dbi6LFkdeBeCz3sHaxRRFVJC2_rF8Z_oYqaoNOpYtzQh61WP78pK7nKT53WsE-7uiBUMamLA8vEGJpFQ3h4MXDi2OKh1YDpphS_pwyDkqYbsguMs2KYqPxe8t1OC2G1o"
     },
     "@context": [

--- a/specifications/testing/sample_input_verification/v-t_0002_valid_vc_embedded_proof.json
+++ b/specifications/testing/sample_input_verification/v-t_0002_valid_vc_embedded_proof.json
@@ -24,12 +24,12 @@
           "x": "eQbMauiHc9HuiqXT894gW5XTCrOpeY8cjLXAckfRtdVBLzVHKaiXAAxBFeVrSB75",
           "y": "YOjxhMkdH9QnNmGCGuGXJrjAtk8CQ1kTmEEi9cg2R9ge-zh8SFT1Xu6awoUjK5Bv"
         },
-        "id": "https://org.eclipse.tractusx/keys/68c7189c-b849-4f85-b27d-c796c7cf29ed"
+        "id": "https://org.eclipse.placeholder/keys/68c7189c-b849-4f85-b27d-c796c7cf29ed"
       },
       "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzM4NCJ9..0ueANOomarONwEL2Y0QnCFjgOdgPjI8kL2Wk4QWh8SJjvVTR80ASVh7bi8HlQp6dUigP3r509oMQkXB6TEddi0D8oQc2Lv0uWxl7yxPInBcfIsWmQrFBTb4mCSU_MJwE"
     },
     "@context": [
-      "https://org.eclipse.tractusx/businessPartnerData",
+      "https://org.eclipse.placeholder/businessPartnerData",
       "https://www.w3.org/2018/credentials/v1",
       "https://w3id.org/security/suites/jws-2020/v1",
       "https://www.w3.org/ns/did/v1"

--- a/specifications/testing/sample_input_verification/v-t_0003.a_vc_embedded_forged_claim.json
+++ b/specifications/testing/sample_input_verification/v-t_0003.a_vc_embedded_forged_claim.json
@@ -24,12 +24,12 @@
         "x": "eQbMauiHc9HuiqXT894gW5XTCrOpeY8cjLXAckfRtdVBLzVHKaiXAAxBFeVrSB75",
         "y": "YOjxhMkdH9QnNmGCGuGXJrjAtk8CQ1kTmEEi9cg2R9ge-zh8SFT1Xu6awoUjK5Bv"
       },
-      "id": "https://org.eclipse.tractusx/keys/68c7189c-b849-4f85-b27d-c796c7cf29ed"
+      "id": "https://org.eclipse.placeholder/keys/68c7189c-b849-4f85-b27d-c796c7cf29ed"
     },
     "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzM4NCJ9..0ueANOomarONwEL2Y0QnCFjgOdgPjI8kL2Wk4QWh8SJjvVTR80ASVh7bi8HlQp6dUigP3r509oMQkXB6TEddi0D8oQc2Lv0uWxl7yxPInBcfIsWmQrFBTb4mCSU_MJwE"
   },
   "@context": [
-    "https://org.eclipse.tractusx/businessPartnerData.json",
+    "https://org.eclipse.placeholder/businessPartnerData.json",
     "https://www.w3.org/2018/credentials/v1",
     "https://w3id.org/security/suites/jws-2020/v1",
     "https://www.w3.org/ns/did/v1"

--- a/specifications/testing/sample_input_verification/v-t_0003.b_vc_embedded_altered_credentialsubject.json
+++ b/specifications/testing/sample_input_verification/v-t_0003.b_vc_embedded_altered_credentialsubject.json
@@ -23,12 +23,12 @@
         "x": "eQbMauiHc9HuiqXT894gW5XTCrOpeY8cjLXAckfRtdVBLzVHKaiXAAxBFeVrSB75",
         "y": "YOjxhMkdH9QnNmGCGuGXJrjAtk8CQ1kTmEEi9cg2R9ge-zh8SFT1Xu6awoUjK5Bv"
       },
-      "id": "https://org.eclipse.tractusx/keys/68c7189c-b849-4f85-b27d-c796c7cf29ed"
+      "id": "https://org.eclipse.placeholder/keys/68c7189c-b849-4f85-b27d-c796c7cf29ed"
     },
     "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzM4NCJ9..0ueANOomarONwEL2Y0QnCFjgOdgPjI8kL2Wk4QWh8SJjvVTR80ASVh7bi8HlQp6dUigP3r509oMQkXB6TEddi0D8oQc2Lv0uWxl7yxPInBcfIsWmQrFBTb4mCSU_MJwE"
   },
   "@context": [
-    "https://org.eclipse.tractusx/businessPartnerData",
+    "https://org.eclipse.placeholder/businessPartnerData",
     "https://www.w3.org/2018/credentials/v1",
     "https://w3id.org/security/suites/jws-2020/v1",
     "https://www.w3.org/ns/did/v1"

--- a/specifications/testing/sample_input_verification/v-t_0003.c_vc_embedded_altered_claim.json
+++ b/specifications/testing/sample_input_verification/v-t_0003.c_vc_embedded_altered_claim.json
@@ -24,12 +24,12 @@
           "x": "eQbMauiHc9HuiqXT894gW5XTCrOpeY8cjLXAckfRtdVBLzVHKaiXAAxBFeVrSB75",
           "y": "YOjxhMkdH9QnNmGCGuGXJrjAtk8CQ1kTmEEi9cg2R9ge-zh8SFT1Xu6awoUjK5Bv"
         },
-        "id": "https://org.eclipse.tractusx/keys/68c7189c-b849-4f85-b27d-c796c7cf29ed"
+        "id": "https://org.eclipse.placeholder/keys/68c7189c-b849-4f85-b27d-c796c7cf29ed"
       },
       "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzM4NCJ9..0ueANOomarONwEL2Y0QnCFjgOdgPjI8kL2Wk4QWh8SJjvVTR80ASVh7bi8HlQp6dUigP3r509oMQkXB6TEddi0D8oQc2Lv0uWxl7yxPInBcfIsWmQrFBTb4mCSU_MJwE"
     },
     "@context": [
-      "https://org.eclipse.tractusx/businessPartnerData",
+      "https://org.eclipse.placeholder/businessPartnerData",
       "https://www.w3.org/2018/credentials/v1",
       "https://w3id.org/security/suites/jws-2020/v1",
       "https://www.w3.org/ns/did/v1"

--- a/specifications/testing/sample_input_verification/v-t_0004.a_vc_embedded_forged_proof.json
+++ b/specifications/testing/sample_input_verification/v-t_0004.a_vc_embedded_forged_proof.json
@@ -24,12 +24,12 @@
         "x": "eQbMauiHc9HuiqXT894gW5XTCrOpeY8cjLXAckfRtdVBLzVHKaiXAAxBFeVrSB75",
         "y": "YOjxhMkdH9QnNmGCGuGXJrjAtk8CQ1kTmEEi9cg2R9ge-zh8SFT1Xu6awoUjK5Bv"
       },
-      "id": "https://org.eclipse.tractusx/keys/68c7189c-b849-4f85-b27d-c796c7cf29ed"
+      "id": "https://org.eclipse.placeholder/keys/68c7189c-b849-4f85-b27d-c796c7cf29ed"
     },
     "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzM4NCJ9..xJWgUGQLLeC6XqZKXfkboY49NJeKW7GCOvqvXsP2iCXijMQVwz3yjCEf_4Hs3xLJZqz7_ZVYOEGeg5k2UMctVQ_uwsrPZ6w72jq4pMaNAlUIEeRDLYVUSl6v2FoeZftt"
   },
   "@context": [
-    "https://org.eclipse.tractusx/businessPartnerData",
+    "https://org.eclipse.placeholder/businessPartnerData",
     "https://www.w3.org/2018/credentials/v1",
     "https://w3id.org/security/suites/jws-2020/v1"
   ]

--- a/specifications/testing/sample_input_verification/v-t_0004.b_vc_embedded_invalid_proof.json
+++ b/specifications/testing/sample_input_verification/v-t_0004.b_vc_embedded_invalid_proof.json
@@ -24,12 +24,12 @@
           "x": "eQbMXXXHc9HuiqXT894gW5XTCrOpeY8cjLXAckfRtdVBLzVHKaiXAAxBFeVrSB75",
           "y": "YOjxhMkdH9QnNmGCGuGXJrjAtk8CQ1kTmEEi9cg2R9ge-zh8SFT1Xu6awoUjK5Bv"
         },
-        "id": "https://org.eclipse.tractusx/keys/68c7189c-b849-4f85-b27d-c796c7cf29ed"
+        "id": "https://org.eclipse.placeholder/keys/68c7189c-b849-4f85-b27d-c796c7cf29ed"
       },
       "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzM4NCJ9..0ueANOomarONwEL2Y0QnCFjgOdgPjI8kL2Wk4QWh8SJjvVTR80ASVh7bi8HlQp6dUigP3r509oMQkXB6TEddi0D8oQc2Lv0uWxl7yxPInBcfIsWmQrFBTb4mCSU_MJwE"
     },
     "@context": [
-      "https://org.eclipse.tractusx/businessPartnerData",
+      "https://org.eclipse.placeholder/businessPartnerData",
       "https://www.w3.org/2018/credentials/v1",
       "https://w3id.org/security/suites/jws-2020/v1",
       "https://www.w3.org/ns/did/v1"

--- a/specifications/testing/sample_input_verification/v-t_0005_vc_canonicalization.json
+++ b/specifications/testing/sample_input_verification/v-t_0005_vc_canonicalization.json
@@ -20,7 +20,7 @@
         "x": "eQbMauiHc9HuiqXT894gW5XTCrOpeY8cjLXAckfRtdVBLzVHKaiXAAxBFeVrSB75",
         "y": "YOjxhMkdH9QnNmGCGuGXJrjAtk8CQ1kTmEEi9cg2R9ge-zh8SFT1Xu6awoUjK5Bv"
       },
-      "id": "https://org.eclipse.tractusx/keys/68c7189c-b849-4f85-b27d-c796c7cf29ed"
+      "id": "https://org.eclipse.placeholder/keys/68c7189c-b849-4f85-b27d-c796c7cf29ed"
     }
   },
   "credentialSubject": {
@@ -29,7 +29,7 @@
     "type": "BpnCredential"
   },
   "@context": [
-    "https://org.eclipse.tractusx/businessPartnerData",
+    "https://org.eclipse.placeholder/businessPartnerData",
     "https://www.w3.org/2018/credentials/v1",
     "https://w3id.org/security/suites/jws-2020/v1",
     "https://www.w3.org/ns/did/v1"

--- a/specifications/testing/sample_input_verification/v-t_0010_vp_compacted.json
+++ b/specifications/testing/sample_input_verification/v-t_0010_vp_compacted.json
@@ -6,9 +6,9 @@
     "credentialSubject": {
       "http://schema.org/identifier": "BPNL000000000000",
       "id": "did:web:localhost:BPNL000000000000",
-      "type": "https://org.eclipse.tractusx/businessPartnerData#BpnCredential"
+      "type": "https://org.eclipse.placeholder/businessPartnerData#BpnCredential"
     },
-    "id": "https://org.eclipse.tractusx/testcases/t0001",
+    "id": "https://org.eclipse.placeholder/testcases/t0001",
     "type": [
       "VerifiableCredential",
       "BpnCredential"
@@ -19,7 +19,7 @@
       "type": "JsonWebSignature2020",
       "created": "2022-12-31T23:00:00Z",
       "proofPurpose": "assertionMethod",
-      "verificationMethod": "https://org.eclipse.tractusx/verification-method",
+      "verificationMethod": "https://org.eclipse.placeholder/verification-method",
       "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzM4NCJ9..dbi6LFkdeBeCz3sHaxRRFVJC2_rF8Z_oYqaoNOpYtzQh61WP78pK7nKT53WsE-7uiBUMamLA8vEGJpFQ3h4MXDi2OKh1YDpphS_pwyDkqYbsguMs2KYqPxe8t1OC2G1o"
     }
   },
@@ -27,7 +27,7 @@
     "type": "JsonWebSignature2020",
     "created": "2022-12-31T23:00:00Z",
     "proofPurpose": "assertionMethod",
-    "verificationMethod": "https://org.eclipse.tractusx/verification-method",
+    "verificationMethod": "https://org.eclipse.placeholder/verification-method",
     "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzM4NCJ9..qVCNVL_jxQdqa509KPTjRERopJiRtW1CqctVD_uGtUlCNF9oM2eB1L821YvjW0VjZjP6XdS5bLfQpG3azg9Hm8-L4vFBiH8HgEdVllHVcmO1odG-2GQAnhdP6Kdg42Wh"
   },
   "@context": [

--- a/specifications/verifiable.presentation.protocol.md
+++ b/specifications/verifiable.presentation.protocol.md
@@ -36,7 +36,7 @@ issued credentials.
 
 The VPP is based on Json-Ld message types. The CS Json-Ld context is:
 
-`https://w3id.org/tractusx-trust/v0.8`
+`https://w3id.org/dspace-dcp/v0.8`
 
 ### The Base URL
 
@@ -79,21 +79,21 @@ Scopes are used to specify access privileges. A scope is a string value in the f
 
 The `[alias]` value may be implementation-specific. The `all` value indicates both read and write access.
 
-#### The `org.eclipse.tractusx.vc.type` Alias
+#### The `org.eclipse.dspace.dcp.vc.type` Alias
 
 The `vc.type` alias value must be supported and is used to specify access to a verifiable credential by type. For
 example:
 
-`org.eclipse.tractusx.vc.type:Member:read`
+`org.eclipse.dspace.dcp.vc.type:Member:read`
 
 denotes read-only access to the VC type `Member` and may be used to request a VC or VP.
 
-#### The `org.eclipse.tractusx.vc.id` Alias
+#### The `org.eclipse.dspace.dcp.vc.id` Alias
 
-The `org.eclipse.tractusx.vc.id` alias value must be supported and is used to specify access to a verifiable credential
+The `org.eclipse.dspace.dcp.vc.id` alias value must be supported and is used to specify access to a verifiable credential
 by id. For example:
 
-`org.eclipse.tractusx.vc.id:8247b87d-8d72-47e1-8128-9ce47e3d829d:read`
+`org.eclipse.dspace.dcp.vc.id:8247b87d-8d72-47e1-8128-9ce47e3d829d:read`
 
 denotes read-only access to the VC identified by `8247b87d-8d72-47e1-8128-9ce47e3d829d` and may be used to request a VC
 or VP.
@@ -102,7 +102,7 @@ or VP.
 
 Implementations must also support the `*` wildcard:
 
-`org.eclipse.tractusx.vc.type:*:write`
+`org.eclipse.dspace.dcp.vc.type:*:write`
 
 The above expression enables write-only access to all VCs.
 
@@ -150,7 +150,7 @@ The following are non-normative examples of the JSON body:
 ```json
 {
   "@context": [
-    "https://w3id.org/tractusx-trust/v0.8",
+    "https://w3id.org/dspace-dcp/v0.8",
     "https://identity.foundation/presentation-exchange/submission/v1"
   ],
   "@type": "PresentationQueryMessage",
@@ -161,7 +161,7 @@ The following are non-normative examples of the JSON body:
 ```json
 {
   "@context": [
-    "https://w3id.org/tractusx-trust/v0.8",
+    "https://w3id.org/dspace-dcp/v0.8",
     "https://identity.foundation/presentation-exchange/submission/v1"
   ],
   "@type": "PresentationQueryMessage",
@@ -199,7 +199,7 @@ The following are non-normative examples of the JSON response body:
 ```json
 {
   "@context": [
-    "https://w3id.org/tractusx-trust/v0.8"
+    "https://w3id.org/dspace-dcp/v0.8"
   ],
   "@type": "PresentationResponseMessage",
   "presentation": ["dsJdh...UMetV"]
@@ -227,7 +227,7 @@ The following is a non-normative example of the JSON body:
 ```json
 {
   "@context": [
-    "https://w3id.org/tractusx-trust/v0.8"
+    "https://w3id.org/dspace-dcp/v0.8"
   ],
   "@type": "CredentialMessage",
   "credentials": [
@@ -258,7 +258,7 @@ MUST contain at least one `Service` entry ([[did-core]], sect. 5.4) of type `Cre
 {
   "@context": [
     "https://www.w3.org/ns/did/v1",
-    "https://w3id.org/tractusx-trust/v0.8"
+    "https://w3id.org/dspace-dcp/v0.8"
   ],
   "service": [
     {


### PR DESCRIPTION
## WHAT

Removes the references to Tractus-X repository after transfer to Eclipse Foundation.

- [x] remove references in README and other text 
- [x] change context reference from `https://w3id.org/tractusx-trust/v0.8` → `https://w3id.org/dspace-dcp/v0.8`.
- [x] references to `https://org.eclipse.tractusx`
