### PR TITLE
fix: load correct topology file after renaming (#79)

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
     </p>
 </section>
 
-<section data-include="specifications/tx.dataspace.topology.md" data-include-format="markdown">
+<section data-include="specifications/dataspace.topology.md" data-include-format="markdown">
 </section>
 
 <section data-include="specifications/identity.protocol.base.md" data-include-format="markdown">


### PR DESCRIPTION
## WHAT

The current rendering (since #79) doesn't import the topology section anymore since the renaming. This PR fixes that.