### PR TITLE
feat: add requestId to CredentialMessage

### DIFF
--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -293,7 +293,7 @@ The following is a non-normative example of a `IssuerMetadata` response object:
 
 The issuer MUST provide an `HTTPS GET` endpoint for retrieving the status of a credential at the base issuer url with
 the appended path `/requests/<request id>`. The issuer SHOULD implement access control such that only the client that
-made the request may access a particualr request status.
+made the request may access a particular request status.
 
 If accepted, a `CredentialStatus` Json object with a `status` property set to one of the following
 values: `RECEIVED` | `REJECTED` | `ISSUED` will be returned.

--- a/specifications/verifiable.presentation.protocol.md
+++ b/specifications/verifiable.presentation.protocol.md
@@ -134,7 +134,7 @@ Presentations can be queried by POSTing a `PresentationQueryMessage` message to 
 
 `POST /presentations/query`
 
-The POST body is a `CredentialMessage` JSON object with the following properties:
+The POST body is a `PresentationQueryMessage` JSON object with the following properties:
 
 - `@context`: REQUIRED. Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).
 - `@type`: REQUIRED. A string specifying the `PresentationQueryMessage` type.
@@ -219,6 +219,7 @@ The POST body is a `CredentialMessage` JSON object with the following properties
 
 - `@context`: REQUIRED. Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).
 - `@type`: REQUIRED. A string specifying the `CredentialMessage` type.
+- `requestId`: REQUIRED. A string corresponding to the request id.
 - `credentials`: REQUIRED. An array of `CredentialContainer` Json objects corresponding to the schema
   specified in section [[[#the-credentialcontainer-object]]].
 
@@ -235,7 +236,8 @@ The following is a non-normative example of the JSON body:
       "@type": "CredentialContainer",
       "payload": ""
     }
-  ]
+  ],
+  "requestId": "..."
 }
 ```
 


### PR DESCRIPTION
## WHAT

Add correlation ids for issuance message exchanges to make async message requests and replies for issuance traceable.

Closes #70

## How was the issue fixed?

The `requestId` property was added to the `CredentialMessage` type. 

## More context

see #70 