### PR TITLE
chore: auto-include readme as abstract in website build

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,27 +39,7 @@
     This document is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">The Apache License, Version 2.0</a>.
 </p>
 <h1 id="title">Eclipse Decentralized Claims Protocol</h1>
-<section id='abstract'>
-    <p>
-        This repository contains normative documents defining protocols and flows withing the Identity and Trust system
-        to be used in Tractus-X projects.
-    </p>
-</section>
-<section id='sotd'>
-    <p>
-        The responsibility of the specification has been transfered to the <a href="https://dataspace.eclipse.org/">Eclipse
-        Dataspace Working Group</a>.
-        Please file
-        change requests or contributions according to the working group processes. Until the first version of the
-        specification from the working group is released and implemented, this repository contains the current
-        specification implemented in the Catena-X data space. Maintenance is limited to urgent issues concerning the
-        operation of this data space. There are <a
-            href="https://github.com/eclipse-tractusx/identity-trust/blob/main/pr_etiquette.md#the-designated-editors-as-of-sept-21-2023">designated
-        editors</a>,
-        who are the primary contributors to the content of
-        this repository. Please file urgent issues that cannot wait for the first working group release through GitHub
-        Discussions or Issues.
-    </p>
+<section id='abstract' data-include="README.md" data-include-format="markdown">
 </section>
 
 <section data-include="specifications/dataspace.topology.md" data-include-format="markdown">


### PR DESCRIPTION
## WHAT

_Briefly describe what your PR changes, which features it adds/modifies._

Currently, the introduction and "state of the document" sections are hard-copied from the README.md. This PR automatically builds the README as the "abstract" section in respec. This relieves the burden of double maintenance.

## How was the issue fixed?

use respec `data-include` mechanism.

## More context

_List other areas that have changed but are not necessarily linked to the main feature. This could be naming changes,
bugs that were encountered and were fixed inline, etc._