### PR TITLE
fix: update definition of credential service

### DIFF
--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -24,7 +24,7 @@ associated with manual workflows that are best modelled using asynchronous messa
 
 ### Terms
 
-- **Credential Service** - The CS is a network-accessible service that manages Verifiable Credentials [[vc-data-model]]. This includes read and write endpoints
+- **Credential Service (CS)** - The CS is a network-accessible service that manages Verifiable Credentials [[vc-data-model]]. This includes read and write endpoints
   for Verifiable Presentations (VPs) and Verifiable Credentials (VCs).
 - **Resource** - A resource is an entity managed by the Credential Service such as a Verifiable Credential (
   VC) or Verifiable Presentation (VP).

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -24,7 +24,8 @@ associated with manual workflows that are best modelled using asynchronous messa
 
 ### Terms
 
-- **Credential Service** - A network-accessible service that manages identity resources.
+- **Credential Service** - The CS is a network-accessible service that manages Verifiable Credentials [[vc-data-model]]. This includes read and write endpoints
+  for Verifiable Presentations (VPs) and Verifiable Credentials (VCs).
 - **Resource** - A resource is an entity managed by the Credential Service such as a Verifiable Credential (
   VC) or Verifiable Presentation (VP).
 - **Holder** - An entity that possesses a set of identity resources as defined by

--- a/specifications/dataspace.topology.md
+++ b/specifications/dataspace.topology.md
@@ -67,7 +67,7 @@ control of the same participant.
 
 #### Credential Service (CS)
 
-The CS manages Verifiable Credentials [[vc-data-model]]. This includes read and write endpoints
+The CS is a network-accessible service that manages Verifiable Credentials [[vc-data-model]]. This includes read and write endpoints
 for Verifiable Presentations (VPs) and Verifiable Credentials (VCs).
 
 #### DID Service (DIDS).

--- a/specifications/verifiable.presentation.protocol.md
+++ b/specifications/verifiable.presentation.protocol.md
@@ -22,7 +22,7 @@ issued credentials.
 
 ### Terms
 
-- **Credential Service** - The CS is a network-accessible service that manages Verifiable Credentials [[vc-data-model]]. This includes read and write endpoints
+- **Credential Service (CS)** - The CS is a network-accessible service that manages Verifiable Credentials [[vc-data-model]]. This includes read and write endpoints
   for Verifiable Presentations (VPs) and Verifiable Credentials (VCs).
 - **Resource** - A resource is an entity managed by the Credential Service such as a Verifiable Credential (
   VC) or Verifiable Presentation (VP).

--- a/specifications/verifiable.presentation.protocol.md
+++ b/specifications/verifiable.presentation.protocol.md
@@ -22,7 +22,8 @@ issued credentials.
 
 ### Terms
 
-- **Credential Service** - A network-accessible service that manages identity resources.
+- **Credential Service** - The CS is a network-accessible service that manages Verifiable Credentials [[vc-data-model]]. This includes read and write endpoints
+  for Verifiable Presentations (VPs) and Verifiable Credentials (VCs).
 - **Resource** - A resource is an entity managed by the Credential Service such as a Verifiable Credential (
   VC) or Verifiable Presentation (VP).
 - **Holder** - An entity that possesses a set of identity resources as defined by


### PR DESCRIPTION
## WHAT
The definition of the Credential Service was inconsistent among the different specification documents.

Closes #57

## How was the issue fixed?

The term definition was aligned among all specification documents.