### PR TITLE
feat: publish artifacts: json-ld context and json schemas on gh-pages

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -1,11 +1,8 @@
 name: Verify Artifacts
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "artifacts/**"  
+  workflow_call:
+    
   workflow_dispatch:
 
   pull_request:

--- a/.github/workflows/autopublish.yaml
+++ b/.github/workflows/autopublish.yaml
@@ -6,6 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
+  tests-artifacts:
+    uses: ./.github/workflows/artifacts.yaml
   build:
     name: Build and Validate
     runs-on: ubuntu-22.04
@@ -20,6 +22,9 @@ jobs:
         run: |
           cp specifications/*.png .
           cp specifications/*.yaml .
+          mkdir -p resources/v0.8
+          cp -r artifacts/src/main/resources/* resources/v0.8
+          rm -rf artifacts
       - name: Run Respec
         run:
           npx respec --src index.html --out index.html.build.html -t 60 --disable-sandbox --verbose


### PR DESCRIPTION
## WHAT

- Verify artifacts before publishing
- Publishes resources under `artifacts/src/main/resources` in `resources/v0.8` folder when publishing to gh-pages
- removes artifacts folder from the gh-pages artifact

Relates #63 

## How was the issue fixed?

_Briefly state why the change was necessary._

## More context

_List other areas that have changed but are not necessarily linked to the main feature. This could be naming changes,
bugs that were encountered and were fixed inline, etc._