### PR TITLE
feat: update usage of deprecated VC Credential Status List 

### DIFF
--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -262,7 +262,7 @@ less than the rotation period of the keys used to sign their proofs.
 
 ## Verifiable Credential Revocation
 
-[=Verifiable Credential=] revocation MUST be supported using the [[[vc-bitstring-status-list-20230427]]] specification.
+[=Verifiable Credential=] revocation MUST be supported using the [[[vc-bitstring-status-list]]] specification.
 Note that implementations MAY support multiple lists.
 
 ## ODRL (Open Digital Rights Language) Profile

--- a/specifications/dataspace.ecosystem.md
+++ b/specifications/dataspace.ecosystem.md
@@ -51,5 +51,5 @@ The Issuer Service is run by trust anchor and manages the lifecycle of Verifiabl
 dataspace may contain multiple Issuer Services run by different trust anchors. The Issuer Service:
 
 - Issues VCs for dataspace participants.
-- Manages revocation lists for VC types it issues based on [[[vc-bitstring-status-list-20230427]]].
+- Manages revocation lists for VC types it issues based on [[[vc-bitstring-status-list]]].
 - Provides cryptographic material used to verify VPs and VCs. 


### PR DESCRIPTION
## WHAT
- the Verifiable Credentials Status List v2021 is deprecated and needs to be upgraded within the specification

Closes #56

## How was the issue fixed?

- upgrading the usage of the deprecated VC Bitstring Status List with its successor VC Bitstring Status Lists