### PR TITLE
docs: replace cryptographicSuites with cryptography

### DIFF
--- a/artifacts/src/main/resources/context/dcp.jsonld
+++ b/artifacts/src/main/resources/context/dcp.jsonld
@@ -46,8 +46,8 @@
           "@type": "xsd:string",
           "@container": "@set"
         },
-        "cryptographicSuites": {
-          "@id": "dcp:cryptographicSuites",
+        "cryptography": {
+          "@id": "dcp:cryptography",
           "@type": "xsd:string",
           "@container": "@set"
         },

--- a/artifacts/src/main/resources/issuance/credential-object-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-object-schema.json
@@ -27,7 +27,7 @@
             "type": "string"
           }
         },
-        "cryptographicSuites": {
+        "cryptography": {
           "type": "array",
           "items": {
             "type": "string"
@@ -65,7 +65,7 @@
         "credentialType",
         "offerReason",
         "bindingMethods",
-        "cryptographicSuites",
+        "cryptography",
         "issuancePolicy"
       ]
     }

--- a/artifacts/src/main/resources/issuance/example/credential-object.json
+++ b/artifacts/src/main/resources/issuance/example/credential-object.json
@@ -14,7 +14,7 @@
   "bindingMethods": [
     "did:web"
   ],
-  "cryptographicSuites": [
+  "cryptography": [
     "JsonWebKey2020"
   ],
   "issuancePolicy": {

--- a/artifacts/src/main/resources/issuance/example/credential-object.json
+++ b/artifacts/src/main/resources/issuance/example/credential-object.json
@@ -15,7 +15,7 @@
     "did:web"
   ],
   "cryptography": [
-    "JsonWebKey2020"
+    "JsonWebSignature202", "eddsa-rdfc-2022", "eddsa-jcs-2022", "..."
   ],
   "issuancePolicy": {
     "permission": {

--- a/artifacts/src/main/resources/issuance/example/credential-offer-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-offer-message.json
@@ -18,7 +18,7 @@
       "bindingMethods": [
         "did:web"
       ],
-      "cryptographicSuites": [
+      "cryptography": [
         "JsonWebKey2020"
       ],
       "issuancePolicy": {

--- a/artifacts/src/main/resources/issuance/example/credential-offer-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-offer-message.json
@@ -19,7 +19,7 @@
         "did:web"
       ],
       "cryptography": [
-        "JsonWebSignature202", "eddsa-rdfc-2022", "eddsa-jcs-2022", "..."
+        "JsonWebSignature2020", "eddsa-rdfc-2022", "eddsa-jcs-2022", "..."
       ],
       "issuancePolicy": {
         "permission": {

--- a/artifacts/src/main/resources/issuance/example/credential-offer-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-offer-message.json
@@ -19,7 +19,7 @@
         "did:web"
       ],
       "cryptography": [
-        "JsonWebKey2020"
+        "JsonWebSignature202", "eddsa-rdfc-2022", "eddsa-jcs-2022", "..."
       ],
       "issuancePolicy": {
         "permission": {

--- a/artifacts/src/main/resources/issuance/example/issuer-metadata.json
+++ b/artifacts/src/main/resources/issuance/example/issuer-metadata.json
@@ -17,7 +17,7 @@
       "bindingMethods": [
         "did:web"
       ],
-      "cryptographicSuites": [
+      "cryptography": [
         "JsonWebKey2020"
       ],
       "issuancePolicy": {

--- a/artifacts/src/main/resources/issuance/example/issuer-metadata.json
+++ b/artifacts/src/main/resources/issuance/example/issuer-metadata.json
@@ -18,7 +18,7 @@
         "did:web"
       ],
       "cryptography": [
-        "JsonWebSignature202", "eddsa-rdfc-2022", "eddsa-jcs-2022", "..."
+        "JsonWebSignature2020", "eddsa-rdfc-2022", "eddsa-jcs-2022", "..."
       ],
       "issuancePolicy": {
         "permission": {

--- a/artifacts/src/main/resources/issuance/example/issuer-metadata.json
+++ b/artifacts/src/main/resources/issuance/example/issuer-metadata.json
@@ -18,7 +18,7 @@
         "did:web"
       ],
       "cryptography": [
-        "JsonWebKey2020"
+        "JsonWebSignature202", "eddsa-rdfc-2022", "eddsa-jcs-2022", "..."
       ],
       "issuancePolicy": {
         "permission": {

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialObjectSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialObjectSchemaTest.java
@@ -32,7 +32,7 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
                 "bindingMethods": [
                   "did:web"
                 ],
-                "cryptographicSuites": [
+                "cryptography": [
                   "JsonWebKey2020"
                 ],
                 "issuancePolicy": {
@@ -66,7 +66,7 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
                 "bindingMethods": [
                   "did:web"
                 ],
-                "cryptographicSuites": [
+                "cryptography": [
                   "JsonWebKey2020"
                 ],
                 "issuancePolicy": {
@@ -95,7 +95,7 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
                 .containsExactly(error("credentialType", REQUIRED),
                         error("offerReason", REQUIRED),
                         error("bindingMethods", REQUIRED),
-                        error("cryptographicSuites", REQUIRED),
+                        error("cryptography", REQUIRED),
                         error("issuancePolicy", REQUIRED));
 
         assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_TYPE_AND_CONTEXT, JSON))

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialObjectSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialObjectSchemaTest.java
@@ -33,7 +33,7 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
                   "did:web"
                 ],
                 "cryptography": [
-                  "JsonWebKey2020"
+                  "JsonWebSignature2020"
                 ],
                 "issuancePolicy": {
                   "permission": [
@@ -67,7 +67,7 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
                   "did:web"
                 ],
                 "cryptography": [
-                  "JsonWebKey2020"
+                  "JsonWebSignature2020"
                 ],
                 "issuancePolicy": {
                   "permission": [

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -210,7 +210,7 @@ The following is a non-normative example of a credential offer request:
 |              | - `@type`: A string specifying the `CredentialObject` type                                                         |
 |              | - `credentialType`: An array of strings defining the type of credential being offered                              |
 | **Optional** | - `bindingMethods`: An array of strings defining the key material that an issued credential is bound to            |
-|              | - `cryptographicSuites`: An array of strings defining the algorithm used for credential signing                    |
+|              | - `cryptography`: An array of strings defining the algorithm used for credential signing                    |
 |              | - `issuancePolicy`: An ODRL Policy [[odrl-model]]. Note that the ODRL Policy MUST not contain `target` attributes  |
 |              | - `offerReason`: A reason for the offer as a string. Valid values may include `reissue` and `proof-key-revocation` |
 

--- a/specifications/dsp.profile.md
+++ b/specifications/dsp.profile.md
@@ -41,7 +41,7 @@ catalog. The `CredentialsSupported` object contains the following properties:
 - `types`: REQUIRED. An array of verifiable credential type strings the credential corresponds to
 - `bindingMethod`: REQUIRED. String that identifies how the credential is bound to the identifier of the
   credential holder.
-- `cryptographicSuites` REQUIRED. An array of strings that identify the cryptographic suites supported for verifying
+- `cryptography` REQUIRED. An array of strings that identify the cryptographic suites supported for verifying
   proofs. Values should either use those defined
   by [IANA JOSE](https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms) for JWT-based VCs
   or the [Linked Data Cryptographic Suite Registry](https://w3c-ccg.github.io/ld-cryptosuite-registry/) for LD-based

--- a/specifications/dsp.profile.md
+++ b/specifications/dsp.profile.md
@@ -41,7 +41,7 @@ catalog. The `CredentialsSupported` object contains the following properties:
 - `types`: REQUIRED. An array of verifiable credential type strings the credential corresponds to
 - `bindingMethod`: REQUIRED. String that identifies how the credential is bound to the identifier of the
   credential holder.
-- `cryptography` REQUIRED. An array of strings that identify the cryptographic suites supported for verifying
+- `cryptography` REQUIRED. An array of strings that identify the cryptographic standards supported for verifying
   proofs. Values should either use those defined
   by [IANA JOSE](https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms) for JWT-based VCs
   or the [Linked Data Cryptographic Suite Registry](https://w3c-ccg.github.io/ld-cryptosuite-registry/) for LD-based


### PR DESCRIPTION
## WHAT

changes the wording from `cryptographicSuites` to `cryptography` to be more generic

Closes #94

## How was the issue fixed?

JsonWebKey2020 is not a cryptographic suite, it is a way to publicize key material. The term "cryptographic suite" is based on a discontinued draft spec, so we opted for the more generic `"cryptography`

## More context

_List other areas that have changed but are not necessarily linked to the main feature. This could be naming changes,
bugs that were encountered and were fixed inline, etc._
