### PR TITLE
Replace odrl `issuancePolicy` with presentation definition

### DIFF
--- a/artifacts/src/main/resources/context/dcp.jsonld
+++ b/artifacts/src/main/resources/context/dcp.jsonld
@@ -51,7 +51,10 @@
           "@type": "xsd:string",
           "@container": "@set"
         },
-        "issuancePolicy": "dcp:issuancePolicy"
+        "issuancePolicy": {
+          "@id": "dcp:issuancePolicy",
+          "@type":"@json"
+        }
       }
     },
     "CredentialOfferMessage": {

--- a/artifacts/src/main/resources/issuance/credential-object-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-object-schema.json
@@ -34,7 +34,8 @@
           }
         },
         "issuancePolicy": {
-          "type": "object"
+          "type": "object",
+          "$ref": "https://identity.foundation/presentation-exchange/schemas/presentation-definition.json"
         }
       },
       "oneOf": [

--- a/artifacts/src/main/resources/issuance/example/credential-object.json
+++ b/artifacts/src/main/resources/issuance/example/credential-object.json
@@ -15,18 +15,30 @@
     "did:web"
   ],
   "cryptography": [
-    "JsonWebSignature202", "eddsa-rdfc-2022", "eddsa-jcs-2022", "..."
+    "JsonWebSignature2020",
+    "eddsa-rdfc-2022",
+    "eddsa-jcs-2022",
+    "..."
   ],
   "issuancePolicy": {
-    "permission": {
-      "action": "use",
-      "constraint": {
-        "and": {
-          "leftOperand": "CredentialPrereq",
-          "operator": "eq",
-          "rightOperand": "active"
+    "id": "Scalable trust example",
+    "input_descriptors": [
+      {
+        "id": "pd-id",
+        "constraints": {
+          "fields": [
+            {
+              "path": [
+                "$.holderIdentifier"
+              ],
+              "filter": {
+                "type": "string",
+                "pattern": "^BPN[LS][a-zA-Z0-9]{12}$"
+              }
+            }
+          ]
         }
       }
-    }
+    ]
   }
 }

--- a/artifacts/src/main/resources/issuance/example/credential-offer-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-offer-message.json
@@ -22,16 +22,25 @@
         "JsonWebSignature2020", "eddsa-rdfc-2022", "eddsa-jcs-2022", "..."
       ],
       "issuancePolicy": {
-        "permission": {
-          "action": "use",
-          "constraint": {
-            "and": {
-              "leftOperand": "CredentialPrereq",
-              "operator": "eq",
-              "rightOperand": "active"
+        "id": "Scalable trust example",
+        "input_descriptors": [
+          {
+            "id": "pd-id",
+            "constraints": {
+              "fields": [
+                {
+                  "path": [
+                    "$.holderIdentifier"
+                  ],
+                  "filter": {
+                    "type": "string",
+                    "pattern": "^BPN[LS][a-zA-Z0-9]{12}$"
+                  }
+                }
+              ]
             }
           }
-        }
+        ]
       }
     }
   ]

--- a/artifacts/src/main/resources/issuance/example/issuer-metadata.json
+++ b/artifacts/src/main/resources/issuance/example/issuer-metadata.json
@@ -21,16 +21,25 @@
         "JsonWebSignature2020", "eddsa-rdfc-2022", "eddsa-jcs-2022", "..."
       ],
       "issuancePolicy": {
-        "permission": {
-          "action": "use",
-          "constraint": {
-            "and": {
-              "leftOperand": "CredentialPrereq",
-              "operator": "eq",
-              "rightOperand": "active"
+        "id": "Scalable trust example",
+        "input_descriptors": [
+          {
+            "id": "pd-id",
+            "constraints": {
+              "fields": [
+                {
+                  "path": [
+                    "$.holderIdentifier"
+                  ],
+                  "filter": {
+                    "type": "string",
+                    "pattern": "^BPN[LS][a-zA-Z0-9]{12}$"
+                  }
+                }
+              ]
             }
           }
-        }
+        ]
       }
     }
   ]

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialObjectSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialObjectSchemaTest.java
@@ -36,22 +36,28 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
                   "JsonWebSignature2020"
                 ],
                 "issuancePolicy": {
-                  "permission": [
+                  "id": "Scalable trust example",
+                  "input_descriptors": [
                     {
-                      "action": "use",
-                      "constraint": {
-                        "and": [
+                      "id": "pd-id",
+                      "constraints": {
+                        "fields": [
                           {
-                            "leftOperand": "CredentialPrereq",
-                            "operator": "eq",
-                            "rightOperand": "active"
+                            "path": [
+                              "$.holderIdentifier"
+                            ],
+                            "filter": {
+                              "type": "string",
+                              "pattern": "^BPN[LS][a-zA-Z0-9]{12}$"
+                            }
                           }
                         ]
                       }
                     }
                   ]
                 }
-            }""";
+            }
+            """;
 
     private static final String INVALID_CREDENTIAL_OBJECT = """
             {
@@ -99,7 +105,7 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
                         error("issuancePolicy", REQUIRED));
 
         assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_TYPE_AND_CONTEXT, JSON))
-                .hasSize(3)
+                .hasSize(6)
                 .extracting(this::errorExtractor)
                 .contains(error("type", REQUIRED), error("@type", REQUIRED));
 

--- a/index.html
+++ b/index.html
@@ -30,6 +30,12 @@
               status: "unofficial",
               publisher: "Eclipse Dataspace Working Group",
   			},
+  			"presentation-ex": {
+              title: "Presentation Exchange 2.1.1",
+              href: "https://identity.foundation/presentation-exchange/spec/v2.1.1/",
+              status: "unofficial",
+              publisher: "Decentralized Identity Foundation",
+  			},
           },
         };
     </script>

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -203,16 +203,16 @@ The following is a non-normative example of a credential offer request:
 
 ### CredentialObject
 
-|              |                                                                                                                    |
-|--------------|--------------------------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/v0.8/issuance/credential-object-schema.json)                                             |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                        |
-|              | - `@type`: A string specifying the `CredentialObject` type                                                         |
-|              | - `credentialType`: An array of strings defining the type of credential being offered                              |
-| **Optional** | - `bindingMethods`: An array of strings defining the key material that an issued credential is bound to            |
-|              | - `cryptography`: An array of strings defining the algorithm used for credential signing                    |
-|              | - `issuancePolicy`: An ODRL Policy [[odrl-model]]. Note that the ODRL Policy MUST not contain `target` attributes  |
-|              | - `offerReason`: A reason for the offer as a string. Valid values may include `reissue` and `proof-key-revocation` |
+|              |                                                                                                                                                                                                                               |
+|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Schema**   | [JSON Schema](./resources/v0.8/issuance/credential-object-schema.json)                                                                                                                                                        |
+| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                                                                                                                                   |
+|              | - `@type`: A string specifying the `CredentialObject` type                                                                                                                                                                    |
+|              | - `credentialType`: An array of strings defining the type of credential being offered                                                                                                                                         |
+| **Optional** | - `bindingMethods`: An array of strings defining the key material that an issued credential is bound to                                                                                                                       |
+|              | - `cryptography`: An array of strings defining the algorithm used for credential signing                                                                                                                                      |
+|              | - `issuancePolicy`: A [presentation definition](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-definition) [[presentation-ex]] signifying the required [=Verifiable Presentation=] for issuance. |
+|              | - `offerReason`: A reason for the offer as a string. Valid values may include `reissue` and `proof-key-revocation`                                                                                                            |
 
 The following is a non-normative example of a `CredentialObject`:
 
@@ -309,76 +309,3 @@ less than the rotation period of the keys used to sign their proofs.
 
 [=Verifiable Credential=] revocation MUST be supported using the [[[vc-bitstring-status-list-20230427]]] specification.
 Note that implementations MAY support multiple lists.
-
-## ODRL (Open Digital Rights Language) Profile
-
-An ODRL issuance and re-issuance policy may be associated with a set of `scopes` or
-a [DIF Presentation Exchange presentation definition](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-definition).
-
-This specification defines two ODRL attributes for the Policy class [[odrl]] sect. 2.1) under the `dspace-dcp`
-namespace:
-
-- **scope** - Either a single `string` or an `array` of strings containing `scope` values
-- **presentationDefinition** - Either an object containing an `@id` attribute with a URI value referencing
-  a `presentation definition`, or a `presentation definition` object.
-
-It is an error to specify both attributes. The value of these attributes identify `Verifiable Presentations` required
-for issuance or re-issuance.
-
-The following are non-normative examples of the `scope` attribute:
-
-<aside class="example" title="Array of scopes">
-   <pre class="json">
-{
-  "issuancePolicy": {
-    "scope": [
-      "example_scope1",
-      "example_scope2"
-    ]
-  }
-}
-   </pre>
-</aside>
-
-and
-
-<aside class="example" title="String scope">
-   <pre class="json">
-{
-  "issuancePolicy": {
-    "scope": "example_scope1"
-  }
-}
-   </pre>
-</aside>
-
-The following is a non-normative examples of the `presentationDefinitiion` attribute:
-
-<aside class="example" title="Presentation definition reference">
-   <pre class="json">
-{
-  "issuancePolicy": {
-    "presentationDefinition": {
-      "@id": "https://expample.com/example_definition"
-    }
-  }
-}
-   </pre>
-</aside>
-
-and
-
-<aside class="example" title="Presentation definition object">
-   <pre class="json">
-{
-  "issuancePolicy": {
-    "presentationDefinition": {
-      "id": "example_presentation_definition",
-      "input_descriptors": [
-        "..."
-      ]
-    }
-  }
-}
-   </pre>
-</aside>

--- a/specifications/verifiable.presentation.protocol.md
+++ b/specifications/verifiable.presentation.protocol.md
@@ -97,13 +97,13 @@ exact error code is implementation-specific.
 
 ### Presentation Query Message
 
-|              |                                                                                                                                                                                                               |
-|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/v0.8/presentation/presentation-query-message-schema.json)                                                                                                                           |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                                                                                                                                    |
-|              | - `type`: A string specifying the `PresentationQueryMessage` type.                                                                                                                                           |
-| **Optional** | - `scope`: An array of scopes corresponding to Section [[[#scopes]]].                                                                                                                                         |
-|              | - `presentationDefinition`: A valid `Presentation Definition` according to the [Presentation Exchange Specification](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-definition). |
+|              |                                                                                                      |
+|--------------|------------------------------------------------------------------------------------------------------|
+| **Schema**   | [JSON Schema](./resources/v0.8/presentation/presentation-query-message-schema.json)                  |
+| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                           |
+|              | - `type`: A string specifying the `PresentationQueryMessage` type.                                   |
+| **Optional** | - `scope`: An array of scopes corresponding to Section [[[#scopes]]].                                |
+|              | - `presentationDefinition`: A valid `Presentation Definition` according to [[presentation-ex]]. |
 
 A `PresentationQueryMessage` MUST contain either a `presentationDefinition` or a `scope` parameter. It is an error to
 contain both.


### PR DESCRIPTION
## WHAT

Having ODRL in the specification as signal what kind of credentials to present is an unnecessary indirection. Rather, this information can be conveyed to a Holder more efficiently by reusing the `presentationDefinition` object that is already used in the [PresentationQueryMessage](https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/).

Closes #105
## How was the issue fixed?

added reference to schemas, adjusted samples and tests.

## More context

I was thinking if renaming the `issuancePolicy` to `presentationDefinition` in the `CredentialObject` would make sense for consistency's sake but would restrict extensibility, so I'd suggest to leave it as proposed in this PR.
