### PR TITLE
feat: create pipeline to build multiple versions

### DIFF
--- a/.github/scripts/checkout-tags.sh
+++ b/.github/scripts/checkout-tags.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+mkdir -p HEAD
+git fetch --all --tags
+tags_string=$(git tag)
+echo got tag string
+echo $tags_string
+tags_array=($tags_string)
+mv * HEAD
+for tag in "${tags_array[@]}"
+do
+  echo starting with tag $tag
+  mkdir $tag
+  cd $tag
+  git clone https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol.git --depth 1 --branch ${tag} --quiet
+  pwd
+  mv ./decentralized-claims-protocol/* .
+  cd ..
+done
+pwd
+for dir in */; do
+  if [ -f "$dir/index.html" ]; then
+      echo "index exists."
+      mkdir -p $dir/resources
+      cp -r $dir/artifacts/src/main/resources/* $dir/resources
+      rm -rf $dir/artifacts
+  else
+    echo "index does not exist. No copy operations"
+  fi
+done

--- a/.github/scripts/index.html
+++ b/.github/scripts/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh"
+          content="0;url=https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/HEAD"/>
+    <link rel="canonical" href="https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/HEAD"/>
+</head>
+<body>
+<h4>
+    This redirects to the latest working draft <a href="https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/HEAD">here</a>
+</h4>
+</body>
+</html>

--- a/.github/workflows/autopublish.yaml
+++ b/.github/workflows/autopublish.yaml
@@ -18,16 +18,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
-      - name: Copy assets up a level
+      - name: Create Release folders
         run: |
-          cp specifications/*.png .
-          cp specifications/*.yaml .
-          mkdir -p resources/v1.0
-          cp -r artifacts/src/main/resources/* resources/v1.0
-          rm -rf artifacts
-      - name: Run Respec
-        run:
-          npx respec --src index.html --out index.html.build.html -t 60 --disable-sandbox --verbose
+          chmod +x .github/scripts/checkout-tags.sh
+          ./.github/scripts/checkout-tags.sh
+      - name: Redirect top to head
+        run: cp .github/scripts/index.html .
       - uses: actions/upload-pages-artifact@v3
         with:
           path: .

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -9,7 +9,7 @@ where a manual workflow is required.
 The following sequence diagram depicts a non-normative flow where a client interacts with a [=Credential Issuer=] to
 issue a [=Verifiable Credential=]:
 
-![Issuance Flow](issuance.flow.png "Inssuance Flow")
+![Issuance Flow](specifications/issuance.flow.png "Issuance Flow")
 
 1. The client sends a request to its [=Secure Token Service=] for a [=Self-Issued ID Token=]. The API used to make this
    request is implementation specific. The client may include a set of scopes that define the [=Verifiable Credentials=]
@@ -91,8 +91,8 @@ Self-Issued ID Token to provide the pre-authorization code to the issuer.
 
 |              |                                                                                     |
 |--------------|-------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/v0.8/issuance/credential-request-message-schema.json)     |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).>        |
+| **Schema**   | [JSON Schema](./resources/issuance/credential-request-message-schema.json)          |
+| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).         |
 |              | - `@type`: A string specifying the `CredentialRequestMessage` type                  |
 |              | - `format`:  A JSON string that describes the format of the credential to be issued |
 |              | - `type`: A JSON array of strings that specifies the VC type being requested        |
@@ -100,7 +100,7 @@ Self-Issued ID Token to provide the pre-authorization code to the issuer.
 The following is a non-normative example of a `CredentialRequestMessage`:
 
 <aside class="example" title="CredentialRequestMessage">
-    <pre class="json" data-include="./resources/v0.8/issuance/example/credential-request-message.json">
+    <pre class="json" data-include="./resources/issuance/example/credential-request-message.json">
     </pre>
 </aside> 
 
@@ -135,7 +135,7 @@ exact error code is implementation-specific.
 
 |              |                                                                                                                      |
 |--------------|----------------------------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/v0.8/issuance/credential-message-schema.json)                                              |
+| **Schema**   | [JSON Schema](./resources/issuance/credential-message-schema.json)                                                   |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                                           |
 |              | - `@type`: A string specifying the `Credential Message` type.                                                        |
 |              | - `requestId`: A string corresponding to the issuance request id.                                                    |
@@ -144,7 +144,7 @@ exact error code is implementation-specific.
 The following is a non-normative example of the [Credential Message](#credential-message) JSON body:
 
 <aside class="example" title="Credential Message">
-    <pre class="json" data-include="./resources/v0.8/issuance/example/credential-message.json">
+    <pre class="json" data-include="./resources/issuance/example/credential-message.json">
     </pre>
 </aside>
 
@@ -156,7 +156,7 @@ The  [Credential Container](#credential-container) object contains the following
 
 |              |                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/v0.8/issuance/credential-message-schema.json)                                                         |
+| **Schema**   | [JSON Schema](./resources/issuance/credential-message-schema.json)                                                              |
 | **Required** | - `@type`: A string specifying the `CredentialContainer` type.                                                                  |
 |              | - `payload`: A Json Literal ([[json-ld11]], sect. 4.2.2) containing a [=Verifiable Credential=] defined by ([[vc-data-model]]). |
 
@@ -185,7 +185,7 @@ a [=Verifiable Credential=] offer.
 
 |              |                                                                                                                    |
 |--------------|--------------------------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/v0.8/issuance/credential-offer-message-schema.json)                                      |
+| **Schema**   | [JSON Schema](./resources/issuance/credential-offer-message-schema.json)                                           |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                                         |
 |              | - `@type`: A string specifying the `CredentialOfferMessage` type                                                   |
 |              | - `credentialIssuer`:  The [=Credential Issuer=] DID                                                               |
@@ -198,7 +198,7 @@ MUST resolve this string value to the respective object.
 The following is a non-normative example of a credential offer request:
 
 <aside class="example" title="CredentialOfferMessage">
-    <pre class="json" data-include="./resources/v0.8/issuance/example/credential-offer-message.json">
+    <pre class="json" data-include="./resources/issuance/example/credential-offer-message.json">
     </pre>
 </aside>   
 
@@ -206,7 +206,7 @@ The following is a non-normative example of a credential offer request:
 
 |              |                                                                                                                                                                                                                               |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/v0.8/issuance/credential-object-schema.json)                                                                                                                                                        |
+| **Schema**   | [JSON Schema](./resources/issuance/credential-object-schema.json)                                                                                                                                                             |
 | **Required** | - `@type`: A string specifying the `CredentialObject` type                                                                                                                                                                    |
 |              | - `credentialType`: An array of strings defining the type of credential being offered                                                                                                                                         |
 | **Optional** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). As the `credentialObject` is usually embedded, its context is provided by the enveloping object.                                                  |
@@ -218,7 +218,7 @@ The following is a non-normative example of a credential offer request:
 The following is a non-normative example of a `CredentialObject`:
 
 <aside class="example" title="CredentialObject">
-    <pre class="json" data-include="./resources/v0.8/issuance/example/credential-object.json">
+    <pre class="json" data-include="./resources/issuance/example/credential-object.json">
     </pre>
 </aside>  
 
@@ -241,7 +241,7 @@ the endpoint is the base issuer url with the appended path `/.well-known/vci`.
 
 |              |                                                                             |
 |--------------|-----------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/v0.8/issuance/issuer-metadata-schema.json)        |
+| **Schema**   | [JSON Schema](./resources/issuance/issuer-metadata-schema.json)             |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). |
 |              | - `@type`: A string specifying the `IssuerMetadata` type                    |
 |              | - `credentialIssuer`: A string containing the [=Credential Issuer=] DID     |
@@ -250,7 +250,7 @@ the endpoint is the base issuer url with the appended path `/.well-known/vci`.
 The following is a non-normative example of a `IssuerMetadata` response object:
 
 <aside class="example" title="IssuerMetadata">
-    <pre class="json" data-include="./resources/v0.8/issuance/example/issuer-metadata.json">
+    <pre class="json" data-include="./resources/issuance/example/issuer-metadata.json">
     </pre>
 </aside>  
 
@@ -274,7 +274,7 @@ with `Bearer` of the request.
 
 |              |                                                                             |
 |--------------|-----------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/v0.8/issuance/credential-status-schema.json)      |
+| **Schema**   | [JSON Schema](./resources/issuance/credential-status-schema.json)           |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). |
 |              | - `@type`: A string specifying the `CredentialStatus` type                  |
 |              | - `requestId`: A string corresponding to the request id                     |
@@ -283,7 +283,7 @@ with `Bearer` of the request.
 The following is a non-normative example of a `CredentialStatus` response object:
 
 <aside class="example" title="CredentialStatus">
-    <pre class="json" data-include="./resources/v0.8/issuance/example/credential-status.json">
+    <pre class="json" data-include="./resources/issuance/example/credential-status.json">
     </pre>
 </aside>  
 

--- a/specifications/verifiable.presentation.protocol.md
+++ b/specifications/verifiable.presentation.protocol.md
@@ -19,7 +19,7 @@ resolve credential-related resources. The protocol also provides a mechanism for
 The following sequence diagram depicts a non-normative flow where a client interacts with a [=Verifier=] to present a
 [=Verifiable Credential=]:
 
-![alt text 2](auth.flow.png "Presentation Flow")
+![alt text 2](specifications/auth.flow.png "Presentation Flow")
 
 1. The client sends a request to its [=Secure Token Service=] for a [=Self-Issued ID Token=]. The API used to make this
    request is implementation specific. The client may include a set of scopes that define the [=Verifiable Credentials=]
@@ -50,7 +50,7 @@ the [=Credential Service=]. The following is a non-normative example of a `Crede
 {
   "@context": [
     "https://www.w3.org/ns/did/v1",
-    "https://w3id.org/dspace-dcp/v0.8"
+    "https://w3id.org/dspace-dcp/v1.0"
   ],
   "service": [
     {
@@ -97,7 +97,7 @@ exact error code is implementation-specific.
 
 |              |                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/v0.8/presentation/presentation-query-message-schema.json)             |
+| **Schema**   | [JSON Schema](./resources/presentation/presentation-query-message-schema.json)                  |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                      |
 |              | - `type`: A string specifying the `PresentationQueryMessage` type.                              |
 | **Optional** | - `scope`: An array of scopes corresponding to Section [[[#scopes]]].                           |
@@ -109,12 +109,12 @@ contain both.
 The following are non-normative examples of the JSON body:
 
 <aside class="example" title="PresentationQueryMessage with scope">
-    <pre class="json" data-include="./resources/v0.8/presentation/example/presentation-query-message.json">
+    <pre class="json" data-include="./resources/presentation/example/presentation-query-message.json">
     </pre>
 </aside>
 
 <aside class="example" title="PresentationQueryMessage with presentationDefinition">
-    <pre class="json" data-include="./resources/v0.8/presentation/example/presentation-query-message-w-presentation-definition.json">
+    <pre class="json" data-include="./resources/presentation/example/presentation-query-message-w-presentation-definition.json">
     </pre>
 </aside>
 
@@ -162,7 +162,7 @@ denotes read-only access to the VC identified by `8247b87d-8d72-47e1-8128-9ce47e
 
 |              |                                                                                                                                                                                   |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/v0.8/presentation/presentation-response-message-schema.json)                                                                                            |
+| **Schema**   | [JSON Schema](./resources/presentation/presentation-response-message-schema.json)                                                                                                 |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                                                                                       |
 |              | - `type`: A string specifying the `PresentationResponseMessage` type.                                                                                                             |
 |              | - `presentation`: An array of [=Verifiable Presentations=]. The [=Verifiable Presentations=] may be strings, JSON objects, or a combination of both depending on the format.</br> |
@@ -170,6 +170,6 @@ denotes read-only access to the VC identified by `8247b87d-8d72-47e1-8128-9ce47e
 The following are non-normative examples of the JSON response body:
 
 <aside class="example" title="Presentation Response Message">
-    <pre class="json" data-include="./resources/v0.8/presentation/example/presentation-response-message.json">
+    <pre class="json" data-include="./resources/presentation/example/presentation-response-message.json">
     </pre>
 </aside>


### PR DESCRIPTION
## WHAT

This PR automates parts of the release process. Similar to requested in #123, it covers:
- current `main` is rendered under https://arnoweiss.github.io/decentralized-claims-protocol/HEAD/
- entry point redirects to HEAD https://arnoweiss.github.io/decentralized-claims-protocol/
- older tags are pushed to github pages as well (pretty useless since there's [no html there](https://arnoweiss.github.io/decentralized-claims-protocol/0.8.1/README.md) but still)

Closes #123

## How was the issue fixed?

We want to release as automatically as possible while providing readers transparency by publishing multiple iterations.

## More context

This breaks all w3id referrals. This will be fixed for 0.8 in an upcoming PR that will then also adjust links to schemas & examples that reside in paths with `v1.0/resources` instead of `resources/1.0`.

There's a new issue #133 that collects immediate release-activities.