### PR TITLE
fix: mount profiles as appendix

### DIFF
--- a/artifacts/src/main/resources/issuance/example/issuer-metadata.json
+++ b/artifacts/src/main/resources/issuance/example/issuer-metadata.json
@@ -18,7 +18,7 @@
         "did:web"
       ],
       "profiles": [
-        "JsonWebSignature2020", "eddsa-rdfc-2022", "eddsa-jcs-2022", "..."
+        "vc20-bssl/jwt", "vc10-sl2021/jwt", "..."
       ],
       "issuancePolicy": {
         "id": "Scalable trust example",

--- a/index.html
+++ b/index.html
@@ -176,6 +176,10 @@
 </section>
 
 <section id='conformance'></section>
+
+<section class="appendix" data-include="specifications/dcp.profiles.md" data-include-format="markdown">
+</section>
+
 <section id="tof" class="appendix">
     <h1>Notes</h1>
 </section>

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -211,7 +211,7 @@ The following is a non-normative example of a credential offer request:
 |              | - `credentialType`: An array of strings defining the type of credential being offered                                                                                                                                         |
 | **Optional** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). As the `credentialObject` is usually embedded, its context is provided by the enveloping object.                                                  |
 |              | - `bindingMethods`: An array of strings defining the key material that an issued credential is bound to                                                                                                                       |
-|              | - `profiles`: An array of strings containing the aliases of the [profiles](./dcp.profiles.md), e.g. `"vc20-bssl/jwt"`                                                                                                     |
+|              | - `profiles`: An array of strings containing the aliases of the [profiles](#profiles-of-the-decentralized-claims-protocol), e.g. `"vc20-bssl/jwt"`                                                                            |
 |              | - `issuancePolicy`: A [presentation definition](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-definition) [[presentation-ex]] signifying the required [=Verifiable Presentation=] for issuance. |
 |              | - `offerReason`: A reason for the offer as a string. Valid values may include `reissue` and `proof-key-revocation`                                                                                                            |
 


### PR DESCRIPTION
## WHAT

currently the link to the profiles does not point anywhere in the deployment.

## How was the issue fixed?

mount profiles as appendix

## More context

corrected an example too

_List other areas that have changed but are not necessarily linked to the main feature. This could be naming changes,
bugs that were encountered and were fixed inline, etc._