### PR TITLE
fix broken link in specification

### DIFF
--- a/specifications/base.protocol.md
+++ b/specifications/base.protocol.md
@@ -66,7 +66,7 @@ authorization request parameter set to a list of space-delimited scopes the `tok
 `bearer_access_scope` parameter is present, the `token` claim should not be included.
 
 <aside class="note">
-A non-normative OpenAPI spec of an [=STS=] implementing client credentials flow is provided [here](identity-trust-sts-api.yaml)
+A non-normative OpenAPI spec of an [=STS=] implementing client credentials flow is provided [here](specifications/identity-trust-sts-api.yaml)
 </aside>
 
 ### Validating Self-Issued ID Tokens


### PR DESCRIPTION
## WHAT

The link to the OpenAPI STS specification file was broken

Closes #141

## How was the issue fixed?

the link was adjusted to `specifications/identity-trust-sts-api.yaml`