### PR TITLE
fix: examples for did doc entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,14 +6,14 @@
     <script class="remove" src="https://cdn.jsdelivr.net/gh/w3c/respec-mermaid@1.1.0/dist/main.js"></script>
     <script class='remove'>
         var respecConfig = {
-            specStatus: "unofficial",
+            specStatus: "base",
+            publishDate: "2024-12-19",
             latestVersion: "https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/releases/tag/0.8.1",
             postProcess: [window.respecMermaid.createFigures],
             editors: [{
                 name: "Jim Marino",
                 url: "https://github.com/jimmarino",
                 company: "Metaform Systems",
-
             }],
             authors: [
                 {
@@ -131,14 +131,14 @@
             },
         };
     </script>
-    <title>Eclipse Decentralized Claims Protocol v1.0-RC2</title>
+    <title>Eclipse Decentralized Claims Protocol v1.0-RC1</title>
 </head>
 <body>
 <p class="copyright">
     This document is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">The Apache License,
     Version 2.0</a>.
 </p>
-<h1 id="title">Eclipse Decentralized Claims Protocol </br>v1.0-RC2</h1>
+<h1 id="title">Eclipse Decentralized Claims Protocol </br>v1.0-RC1</h1>
 <section id='abstract'>
     <p>
         Dataspaces require the ability to communicate participant identities and credentials to secure data access. This

--- a/index.html
+++ b/index.html
@@ -6,8 +6,7 @@
     <script class="remove" src="https://cdn.jsdelivr.net/gh/w3c/respec-mermaid@1.1.0/dist/main.js"></script>
     <script class='remove'>
         var respecConfig = {
-            specStatus: "base",
-            publishDate: "2024-12-19",
+            specStatus: "unofficial",
             latestVersion: "https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/releases/tag/0.8.1",
             postProcess: [window.respecMermaid.createFigures],
             editors: [{
@@ -131,14 +130,14 @@
             },
         };
     </script>
-    <title>Eclipse Decentralized Claims Protocol v1.0-RC1</title>
+    <title>Eclipse Decentralized Claims Protocol v1.0-RC2</title>
 </head>
 <body>
 <p class="copyright">
     This document is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">The Apache License,
     Version 2.0</a>.
 </p>
-<h1 id="title">Eclipse Decentralized Claims Protocol </br>v1.0-RC1</h1>
+<h1 id="title">Eclipse Decentralized Claims Protocol </br>v1.0-RC2</h1>
 <section id='abstract'>
     <p>
         Dataspaces require the ability to communicate participant identities and credentials to secure data access. This

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -42,6 +42,10 @@ following is a non-normative example of a `Issuer Service` entry:
 <aside class="example" title="Credential Service Entry in DID document">
     <pre class="json">
 {
+  "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"
+    ],
   "service": [
     {
       "id":"did:example:123#issuer-service",

--- a/specifications/verifiable.presentation.protocol.md
+++ b/specifications/verifiable.presentation.protocol.md
@@ -50,7 +50,7 @@ the [=Credential Service=]. The following is a non-normative example of a `Crede
 {
   "@context": [
     "https://www.w3.org/ns/did/v1",
-    "https://w3id.org/dspace-dcp/v1.0"
+    "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"
   ],
   "service": [
     {


### PR DESCRIPTION
## WHAT

The did doc service entries for the `IssuerService` and `CredentialService` were wrong

Closes #151

## How was the issue fixed?

consistency 

## More context

_List other areas that have changed but are not necessarily linked to the main feature. This could be naming changes,
bugs that were encountered and were fixed inline, etc._