### PR TITLE
chore: changed Dataspace Authority to Dataspace Governance Authority to align with the community terminology

### DIFF
--- a/specifications/dataspace.ecosystem.md
+++ b/specifications/dataspace.ecosystem.md
@@ -4,7 +4,7 @@ This section describes the core actors and systems in a dataspace ecosystem that
 adheres to the model defined by the Dataspace Protocol [[dsp-base]]:
 
 - A <dfn>Dataspace</dfn> is a policy-based data sharing context between two or more entities.
-- The <dfn>Dataspace Authority</dfn> is responsible for operational management of a [=dataspace=],
+- The <dfn>Dataspace Governance Authority</dfn> is responsible for operational management of a [=dataspace=],
   including [=participant=] registration and designation of trust credential issuers.
 - A <dfn>Participant</dfn> is a member of the [=dataspace=]. Members may take on different roles, which are attested to
   by verifiable credentials.
@@ -18,12 +18,12 @@ adheres to the model defined by the Dataspace Protocol [[dsp-base]]:
 
 ## Systems
 
-### Dataspace Authority Systems
+### Dataspace Governance Authority Systems
 
 <dfn data-lt="rs | Registration System">Registration System</dfn>
 
 The registration system is responsible for [=participant=] registration, onboarding, and management in a dataspace.
-The registration system is run by the [=Dataspace Authority=] and is outside the scope of this specification.
+The registration system is run by the [=Dataspace Governance Authority=] and is outside the scope of this specification.
 
 ### Participant Agent Systems
 

--- a/specifications/trust.model.md
+++ b/specifications/trust.model.md
@@ -53,7 +53,7 @@ defined in this specification establish consent in the following way:
 Consent is handled by first mapping Dataspace Protocol Offer and Agreement policies [[dsp-base]] to a set of
 required [=Verifiable Credentials=]. The exact mappings are dataspace-specific as policies
 and [=Verifiable Credentials=] are typically defined for a particular domain. The expectation is that these mappings are
-made available by the [=Dataspace Authority=] to [=Participant Agents=] via
+made available by the [=Dataspace Governance Authority=] to [=Participant Agents=] via
 the [=Verifiable Data Registry=]. [=Verifiable Credential=] mapping is done by both the [=Holder=]
 and [=Verifier=] [=Participant Agent=] when a Dataspace Protocol message is sent and received.
 
@@ -97,9 +97,9 @@ The [=Issuer=] expects:
 
 The [=Holder=] expects:
 
-- The [=Dataspace Authority=] to provide a secure list of trusted [=Issuer=] [=DID=]s. How this list is provided is out
+- The [=Dataspace Governance Authority=] to provide a secure list of trusted [=Issuer=] [=DID=]s. How this list is provided is out
   of scope of the current specification but may be part of the [=Verifiable Data Registry=].
-- The [=Dataspace Authority=] to provide a secure list of participant [=DIDs=]. How this list is provided is out
+- The [=Dataspace Governance Authority=] to provide a secure list of participant [=DIDs=]. How this list is provided is out
   of scope of the current specification but may be part of the [=Verifiable Data Registry=].
 - The [=Credential Service=] to maintain integrity and not release data to unauthorized parties.
 - The [=Issuer=] to issue credentials correctly, including binding them to the holder in a tamper-proof way, and
@@ -110,7 +110,7 @@ The [=Holder=] expects:
 
 The [=Verifier=] expects:
 
-- The [=Dataspace Authority=] to provide a secure list of trusted [=Issuer=] [=DID=]s. How this list is provided is out
+- The [=Dataspace Governance Authority=] to provide a secure list of trusted [=Issuer=] [=DID=]s. How this list is provided is out
   of scope of the current specification but may be part of the [=Verifiable Data Registry=]. [=Verifiers=] can
   recognize several [=Dataspace Authorities=].
 


### PR DESCRIPTION
## WHAT

changed Dataspace Authority to Dataspace Governance Authority to align with the community terminology

## More context

The wider Dataspace community has converged on using Dataspace Governance Authority (short DSGA) instead of Dataspace Authority