### PR TITLE
feat: add holderPid and issuerPid for correlation

### DIFF
--- a/artifacts/src/main/resources/context/dcp.jsonld
+++ b/artifacts/src/main/resources/context/dcp.jsonld
@@ -21,10 +21,15 @@
       "@context": {
         "credentials": {
           "@id": "dcp:credentials",
-          "@container": "@set"
+          "@container": "@set",
+          "@type": "@json"
         },
-        "requestId": {
-          "@id": "dcp:requestId",
+        "issuerPid": {
+          "@id": "dcp:issuerPid",
+          "@type": "@id"
+        },
+        "holderPid": {
+          "@id": "dcp:holderPid",
           "@type": "@id"
         }
       }
@@ -69,6 +74,10 @@
     "CredentialRequestMessage": {
       "@id": "dcp:CredentialRequestMessage",
       "@context": {
+        "holderPid": {
+          "@id": "dcp:holderPid",
+          "@type": "@id"
+        },
         "credentials": {
           "@id": "dcp:credentials",
           "@type": "@json"
@@ -79,8 +88,12 @@
     "CredentialStatus": {
       "@id": "dcp:CredentialStatus",
       "@context": {
-        "requestId": {
-          "@id": "dcp:requestId",
+        "holderPid": {
+          "@id": "dcp:holderPid",
+          "@type": "@id"
+        },
+        "issuerPid": {
+          "@id": "dcp:issuerPid",
           "@type": "@id"
         },
         "status": {

--- a/artifacts/src/main/resources/issuance/credential-message-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-message-schema.json
@@ -21,14 +21,17 @@
             "$ref": "https://w3id.org/dspace-dcp/v1.0/presentation/credential-message-schema.json#/definitions/CredentialContainer"
           }
         },
-        "requestId": {
+        "issuerPid": {
+          "type": "string"
+        },
+        "holderPid": {
           "type": "string"
         },
         "credentialType": {
           "type": "string",
           "const": "CredentialMessage"
         },
-        "format":{
+        "format": {
           "type": "string"
         }
       },
@@ -36,7 +39,8 @@
         "@context",
         "type",
         "credentials",
-        "requestId"
+        "issuerPid",
+        "holderPid"
       ]
     },
     "CredentialContainer": {

--- a/artifacts/src/main/resources/issuance/credential-request-message-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-request-message-schema.json
@@ -18,6 +18,9 @@
         "type": {
           "type": "string"
         },
+        "holderPid": {
+          "type": "string"
+        },
         "credentials": {
           "type": "array",
           "items": {
@@ -39,6 +42,7 @@
       },
       "required": [
         "@context",
+        "holderPid",
         "credentials",
         "type"
       ]

--- a/artifacts/src/main/resources/issuance/credential-status-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-status-schema.json
@@ -12,7 +12,10 @@
     "CredentialStatusClass": {
       "type": "object",
       "properties": {
-        "requestId": {
+        "issuerPid": {
+          "type": "string"
+        },
+        "holderPid": {
           "type": "string"
         },
         "status": {
@@ -29,7 +32,8 @@
         }
       },
       "required": [
-        "requestId",
+        "issuerPid",
+        "holderPid",
         "status",
         "type"
       ]

--- a/artifacts/src/main/resources/issuance/example/credential-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-message.json
@@ -15,5 +15,6 @@
       "format": "json-ld"
     }
   ],
-  "requestId": "requestId"
+  "issuerPid": "issuerPid",
+  "holderPid": "holderPid"
 }

--- a/artifacts/src/main/resources/issuance/example/credential-request-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-request-message.json
@@ -3,6 +3,7 @@
     "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"
   ],
   "type": "CredentialRequestMessage",
+  "holderPid": "holderPid",
   "credentials": [
     {
       "credentialType": "MembershipCredential",
@@ -16,6 +17,5 @@
       "credentialType": "Iso9001Credential",
       "format": "vcdm20_jose"
     }
-
   ]
 }

--- a/artifacts/src/main/resources/issuance/example/credential-status.json
+++ b/artifacts/src/main/resources/issuance/example/credential-status.json
@@ -3,6 +3,7 @@
     "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"
   ],
   "type": "CredentialStatus",
-  "requestId": "requestId",
+  "issuerPid": "issuerPid",
+  "holderPid": "holderPid",
   "status": "RECEIVED"
 }

--- a/artifacts/src/test/java/org/eclipse/dcp/context/issuance/IssuanceContextTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/context/issuance/IssuanceContextTest.java
@@ -30,6 +30,11 @@ public class IssuanceContextTest extends AbstractJsonLdTest {
     }
 
     @Test
+    void verifyCredentialMessage() {
+        verifyRoundTrip("/issuance/example/credential-message.json", "/issuance/credential-message-schema.json");
+    }
+
+    @Test
     void verifyCredentialOfferMessage() {
         verifyRoundTrip("/issuance/example/credential-offer-message.json", "/issuance/credential-offer-message-schema.json");
     }
@@ -56,7 +61,8 @@ public class IssuanceContextTest extends AbstractJsonLdTest {
                 {
                     "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
                     "type": "CredentialStatus",
-                    "requestId": "requestId",
+                    "issuerPid": "issuerPid",
+                    "holderPid": "holderPid",
                     "status": "%s"
                 }""".formatted(status);
 

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialMessageSchemaTest.java
@@ -41,7 +41,8 @@ public class CredentialMessageSchemaTest extends AbstractSchemaTest {
                   "format": "json-ld"
                 }
               ],
-              "requestId": "requestId"
+              "issuerPid": "issuerPid",
+              "holderPid": "holderPid"
             }""";
 
     private static final String INVALID_CREDENTIAL_MESSAGE = """
@@ -60,7 +61,8 @@ public class CredentialMessageSchemaTest extends AbstractSchemaTest {
                     "format": "jwt"
                   }
               ],
-              "requestId": "requestId"
+              "issuerPid": "issuerPid",
+              "holderPid": "holderPid"
             }""";
 
 
@@ -73,7 +75,8 @@ public class CredentialMessageSchemaTest extends AbstractSchemaTest {
                      "format": "jwt"
                    }
               ],
-              "requestId": "requestId"
+              "issuerPid": "issuerPid",
+              "holderPid": "holderPid"
             }""";
 
     @Test
@@ -81,7 +84,7 @@ public class CredentialMessageSchemaTest extends AbstractSchemaTest {
         assertThat(schema.validate(CREDENTIAL_MESSAGE_MESSAGE, JSON)).isEmpty();
         assertThat(schema.validate(INVALID_CREDENTIAL_MESSAGE, JSON))
                 .extracting(this::errorExtractor)
-                .containsExactly(error("credentials", REQUIRED), error("requestId", REQUIRED));
+                .containsExactly(error("credentials", REQUIRED), error("issuerPid", REQUIRED), error("holderPid", REQUIRED));
 
         assertThat(schema.validate(INVALID_CREDENTIAL_MESSAGE_INVALID_CREDENTIAL_CONTAINER, JSON))
                 .extracting(this::errorExtractor)

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialRequestMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialRequestMessageSchemaTest.java
@@ -27,6 +27,27 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
             {
               "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
               "type": "CredentialRequestMessage",
+              "holderPid": "holderPid",
+              "credentials": [
+                 {
+                   "credentialType": "MembershipCredential",
+                   "format": "vcdm11_jwt"
+                 },
+                 {
+                   "credentialType": "OrganizationCredential",
+                   "format": "vcdm11_ld"
+                 },
+                 {
+                   "credentialType": "Iso9001Credential",
+                   "format": "vcdm20_jose"
+                 }
+              ]
+            }""";
+
+    private static final String INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_HOLDER_REQUEST_ID = """
+            {
+              "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
+              "type": "CredentialRequestMessage",
               "credentials": [
                  {
                    "credentialType": "MembershipCredential",
@@ -47,6 +68,7 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
             {
               "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
               "type": "CredentialRequestMessage",
+              "holderPid": "holderPid",
               "credentials": [
                  {
                    "credentialType": "MembershipCredential"
@@ -66,6 +88,7 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
             {
               "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
               "type": "CredentialRequestMessage",
+              "holderPid": "holderPid",
               "credentials": [
                  {
                    "format": "vcdm11_ld"
@@ -75,6 +98,7 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
 
     private static final String INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_TYPE_AND_CONTEXT = """
             {
+              "holderPid": "holderPid",
               "credentials": [
                  {
                    "credentialType": "MembershipCredential",
@@ -87,6 +111,11 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
     @Test
     void verifySchema() {
         assertThat(schema.validate(CREDENTIAL_REQUEST_MESSAGE, JSON)).isEmpty();
+
+        assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_HOLDER_REQUEST_ID, JSON))
+                .extracting(this::errorExtractor)
+                .containsExactly(error("holderPid", REQUIRED));
+
         assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_FORMAT, JSON))
                 .extracting(this::errorExtractor)
                 .containsExactly(error("format", REQUIRED));

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialStatusSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialStatusSchemaTest.java
@@ -29,7 +29,8 @@ public class CredentialStatusSchemaTest extends AbstractSchemaTest {
             {
                 "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
                 "type": "CredentialStatus",
-                "requestId": "requestId",
+                "issuerPid": "issuerPid",
+                "holderPid": "holderPid",
                 "status": "%s"
             }""";
 
@@ -41,7 +42,8 @@ public class CredentialStatusSchemaTest extends AbstractSchemaTest {
 
     private static final String INVALID_CREDENTIAL_STATUS_MESSAGE_NO_TYPE_AND_CONTEXT = """
             {
-                "requestId": "requestId",
+                "issuerPid": "issuerPid",
+                "holderPid": "holderPid",
                 "status": "RECEIVED"
             }""";
 
@@ -52,7 +54,7 @@ public class CredentialStatusSchemaTest extends AbstractSchemaTest {
                 .containsExactly(error(null, ENUM));
         assertThat(schema.validate(INVALID_CREDENTIAL_STATUS, JSON))
                 .extracting(this::errorExtractor)
-                .containsExactly(error("requestId", REQUIRED), error("status", REQUIRED));
+                .containsExactly(error("issuerPid", REQUIRED), error("holderPid", REQUIRED), error("status", REQUIRED));
 
         assertThat(schema.validate(INVALID_CREDENTIAL_STATUS_MESSAGE_NO_TYPE_AND_CONTEXT, JSON))
                 .hasSize(2)

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -99,6 +99,7 @@ Self-Issued ID Token to provide the pre-authorization code to the issuer.
 | **Schema**   | [JSON Schema](./resources/issuance/credential-request-message-schema.json)                                                                                                                                                                       |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                                                                                                                                                      |
 |              | - `type`: A string specifying the `CredentialRequestMessage` type                                                                                                                                                                                |
+|              | - `holderPid`: A string corresponding to the request id on the Holder side type                                                                                                                                                                                |
 |              | - `credentials`: a JSON array of objects, each containing a `format`, which is A JSON string <br/>that describes the format of the credential to be issued <br/>and a `type`: A JSON array of strings that specifies the VC type being requested |
 
 The following is a non-normative example of a `CredentialRequestMessage`:
@@ -145,7 +146,8 @@ exact error code is implementation-specific.
 | **Schema**   | [JSON Schema](./resources/issuance/credential-message-schema.json)                                                   |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                                           |
 |              | - `type`: A string specifying the `Credential Message` type.                                                         |
-|              | - `requestId`: A string corresponding to the issuance request id.                                                    |
+|              | - `issuerPid`: A string corresponding to the issuance id on the Issuer side.                           |
+|              | - `holderPid`: A string corresponding to the issuance id on the Holder side.                           |
 |              | - `credentials`: An array of [Credential Container](#credential-container) Json objects as defined in the following. |
 
 The following is a non-normative example of the [Credential Message](#credential-message) JSON body:
@@ -279,13 +281,14 @@ with `Bearer` of the request.
 
 ### CredentialStatus
 
-|              |                                                                             |
-|--------------|-----------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/issuance/credential-status-schema.json)           |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). |
-|              | - `type`: A string specifying the `CredentialStatus` type                   |
-|              | - `requestId`: A string corresponding to the request id                     |
-|              | - `status`: A string with a value of `RECEIVED`, `REJECTED`, or `ISSUED`    |
+|              |                                                                                     |
+|--------------|-------------------------------------------------------------------------------------|
+| **Schema**   | [JSON Schema](./resources/issuance/credential-status-schema.json)                   |
+| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).         |
+|              | - `type`: A string specifying the `CredentialStatus` type                           |
+|              | - `issuerPid`: A string corresponding to the issuance id on the Issuer side    |
+|              | - `holderPid`: A string corresponding to the issuance id on the Holder side    |
+|              | - `status`: A string with a value of `RECEIVED`, `REJECTED`, or `ISSUED`            |
 
 The following is a non-normative example of a `CredentialStatus` response object:
 


### PR DESCRIPTION
## WHAT

adds `holderPid` and `issuerPid` for correlation:

- `requestId` has been renamed to `issuerPid`
- `holderPid` has been introduced for correlating on the `CredentialService`  side the `CredentialRequestMessage` and the subsequent `CredentialMessage`. 

Closes #176 

## How was the issue fixed?

_Briefly state why the change was necessary._

## More context

_List other areas that have changed but are not necessarily linked to the main feature. This could be naming changes,
bugs that were encountered and were fixed inline, etc._