### PR TITLE
fix: remove well-known from Issuer Metadata API

### DIFF
--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -238,11 +238,8 @@ supported by the [=Credential Issuer=].
 |-----------------|----------------------------------|
 | **Sent by**     | A client                         |
 | **HTTP Method** | `GET`                            |
-| **URL Path**    | `/.well-known/vci`               |
-| **Response**    | [[[#issuermetadata]]] `HTTP 200` |                                                    
-
-A credential issuer MUST support the Issuer Metadata endpoint using the HTTPS scheme and the `GET method`. The URL of
-the endpoint is the base issuer url with the appended path `/.well-known/vci`.
+| **URL Path**    | `/metadata`                      |
+| **Response**    | [[[#issuermetadata]]] `HTTP 200` |
 
 ### IssuerMetadata
 


### PR DESCRIPTION
## WHAT

Distinguish Issuer Metadata API based on whether sub-paths are included in the Issuer base URL.
If no sub-path is available, a `.well-known` must be used. If a sub-path is available, the Issuer Metadata API must be hosted without `.well-known` and a `IssuerMetadataService` DID service must be added

Closes #173 

## How was the issue fixed?

Update Issuance protocol specification and added `IssuerMetadataService` entry in the JSON-LD context

## More context

The Issuer may decide on including the `IssuerMetadataService` DID service even if it is provided under a well known endpoint, but for the spec its probably better to not include this.