### PR TITLE
docs: add credential rejection message

### DIFF
--- a/artifacts/src/main/resources/context/dcp.jsonld
+++ b/artifacts/src/main/resources/context/dcp.jsonld
@@ -31,6 +31,13 @@
         "holderPid": {
           "@id": "dcp:holderPid",
           "@type": "@id"
+        },
+        "status": {
+          "@id": "dcp:status",
+          "@type": "@id"
+        },
+        "rejectionReason": {
+          "@id": "dcp:rejectionReason"
         }
       }
     },

--- a/artifacts/src/main/resources/issuance/credential-message-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-message-schema.json
@@ -33,14 +33,21 @@
         },
         "format": {
           "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["ISSUED", "REJECTED"]
+        },
+        "rejectionReason": {
+          "type": "string"
         }
       },
       "required": [
         "@context",
         "type",
-        "credentials",
         "issuerPid",
-        "holderPid"
+        "holderPid",
+        "status"
       ]
     },
     "CredentialContainer": {

--- a/artifacts/src/main/resources/issuance/example/credential-message-rejected.json
+++ b/artifacts/src/main/resources/issuance/example/credential-message-rejected.json
@@ -1,0 +1,10 @@
+{
+  "@context": [
+    "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"
+  ],
+  "type": "CredentialMessage",
+  "issuerPid": "issuerPid",
+  "holderPid": "holderPid",
+  "status": "REJECTED",
+  "rejectionReason": "final approval not granted"
+}

--- a/artifacts/src/main/resources/issuance/example/credential-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-message.json
@@ -16,5 +16,6 @@
     }
   ],
   "issuerPid": "issuerPid",
-  "holderPid": "holderPid"
+  "holderPid": "holderPid",
+  "status": "ISSUED"
 }

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -146,16 +146,27 @@ exact error code is implementation-specific.
 | **Schema**   | [JSON Schema](./resources/issuance/credential-message-schema.json)                                                   |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                                           |
 |              | - `type`: A string specifying the `Credential Message` type.                                                         |
-|              | - `issuerPid`: A string corresponding to the issuance id on the Issuer side.                           |
-|              | - `holderPid`: A string corresponding to the issuance id on the Holder side.                           |
+|              | - `issuerPid`: A string corresponding to the issuance id on the Issuer side.                                         |
+|              | - `holderPid`: A string corresponding to the issuance id on the Holder side.                                         |
+|              | - `status`: A string stating whether the request was successful (`ISSUED`) or rejected (`REJECTED`)                  |
 |              | - `credentials`: An array of [Credential Container](#credential-container) Json objects as defined in the following. |
+|              | - `rejectionReason`: a String containing additional information why a request was rejected. Can be `null`.           |
 
-The following is a non-normative example of the [Credential Message](#credential-message) JSON body:
+The following is a non-normative example of a [Credential Message](#credential-message) JSON body:
 
-<aside class="example" title="Credential Message">
+<aside class="example" title="Credential Message (issued)">
     <pre class="json" data-include="./resources/issuance/example/credential-message.json">
     </pre>
 </aside>
+
+The following example shows a rejected credential request JSON body:
+<aside class="example" title="Credential Message (rejected)">
+    <pre class="json" data-include="./resources/issuance/example/credential-message-rejected.json">
+    </pre>
+</aside>
+
+Note that the `status` applies to the entire request, i.e. a request is considered _rejected_ if at least one credential could not be issued. 
+Allowed values for the `status` are `"ISSUED"` and `"REJECTED"`. The `rejectionReason` field is optional and should not disclose any confidential information.
 
 ### Credential Container
 


### PR DESCRIPTION
## WHAT

Adds a rejection message to the Storage API of the holder

Closes #182

## How was the issue fixed?

added a `status` field (required) and a `rejectionReason` and made the `credentials` array optional

## More context

_List other areas that have changed but are not necessarily linked to the main feature. This could be naming changes,
bugs that were encountered and were fixed inline, etc._
