### PR TITLE
chore: publish `v1.0-RC2`

### DIFF
--- a/.github/scripts/index.html
+++ b/.github/scripts/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="refresh"
-          content="0;url=https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC1"/>
-    <link rel="canonical" href="https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC1"/>
+          content="0;url=https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC2"/>
+    <link rel="canonical" href="https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC2"/>
 </head>
 <body>
 <h4>
-    This redirects to the latest Release Candidate <a href="https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC1">here</a>
+    This redirects to the latest Release Candidate <a href="https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC2">here</a>
 </h4>
 </body>
 </html>

--- a/WEBSITE.md
+++ b/WEBSITE.md
@@ -45,13 +45,12 @@ When wanting to pin and publish a snapshot in time via a separate url-path, foll
 
 When the content is finished, a release requires a first commit with
 
-1. Increase the version in the title of the spec in `index.html`
-2. a tag with the exact version string (like `v1.0-RC1`) on the release commit
-3. to change the redirect in `.github/scripts/index.html` to point to latest release candidate
-4. specifically put in the release date
-5. set the `respecConfig.specStatus` in `index.html` to `base`
+1. a tag with the exact version string (like `v1.0-RC1`) on the release commit
+2. to change the redirect in `.github/scripts/index.html` to point to latest release candidate
+3. set the `respecConfig.publishDate` in `index.html` to a string like `"2025-02-27"`,`
+4. set the `respecConfig.specStatus` in `index.html` to `base`
 
-In case of non major versions with a new namespace, additionally:
+In case of versions with a new namespace, additionally:
 
 5. adjust the textual description of the context URI in the base spec
 6. appended w3id referrals

--- a/index.html
+++ b/index.html
@@ -3,12 +3,11 @@
 <head>
     <meta charset='utf-8'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' async class='remove'></script>
-    <script class="remove" src="https://cdn.jsdelivr.net/gh/w3c/respec-mermaid@1.1.0/dist/main.js"></script>
     <script class='remove'>
         var respecConfig = {
-            specStatus: "unofficial",
+            specStatus: "base",
+            publishDate: "2025-02-27",
             latestVersion: "https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/releases/tag/0.8.1",
-            postProcess: [window.respecMermaid.createFigures],
             editors: [{
                 name: "Jim Marino",
                 url: "https://github.com/jimmarino",

--- a/index.html
+++ b/index.html
@@ -5,8 +5,7 @@
     <script src='https://www.w3.org/Tools/respec/respec-w3c' async class='remove'></script>
     <script class='remove'>
         var respecConfig = {
-            specStatus: "base",
-            publishDate: "2025-02-27",
+            specStatus: "unofficial",
             latestVersion: "https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/releases/tag/0.8.1",
             editors: [{
                 name: "Jim Marino",
@@ -129,14 +128,14 @@
             },
         };
     </script>
-    <title>Eclipse Decentralized Claims Protocol v1.0-RC2</title>
+    <title>Eclipse Decentralized Claims Protocol v1.0-RC3</title>
 </head>
 <body>
 <p class="copyright">
     This document is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">The Apache License,
     Version 2.0</a>.
 </p>
-<h1 id="title">Eclipse Decentralized Claims Protocol </br>v1.0-RC2</h1>
+<h1 id="title">Eclipse Decentralized Claims Protocol </br>v1.0-RC3</h1>
 <section id='abstract'>
     <p>
         Dataspaces require the ability to communicate participant identities and credentials to secure data access. This


### PR DESCRIPTION
## WHAT

This PR publishes a separate github page for the current state of the spec as a second Release Candidate for version v1 of the DCP.

## More context

As I have push rights, I'll push the tag directly after the PR is merged and rerun the actions accordingly. 

This will lead to a setup like in my fork:
https://arnoweiss.github.io/decentralized-claims-protocol
https://arnoweiss.github.io/decentralized-claims-protocol/v1.0-RC1/
https://arnoweiss.github.io/decentralized-claims-protocol/v1.0-RC2/
https://arnoweiss.github.io/decentralized-claims-protocol/HEAD/