### PR TITLE
feat: usage of the term issuer from VC data model

### DIFF
--- a/artifacts/src/main/resources/context/dcp.jsonld
+++ b/artifacts/src/main/resources/context/dcp.jsonld
@@ -71,7 +71,10 @@
     "CredentialOfferMessage": {
       "@id": "dcp:CredentialOfferMessage",
       "@context": {
-        "credentialIssuer": "cred:issuer",
+        "issuer": {
+          "@id": "cred:issuer",
+          "@type": "@id"
+        },
         "credentials": {
           "@id": "dcp:credentials",
           "@container": "@set"
@@ -115,7 +118,10 @@
     "IssuerMetadata": {
       "@id": "dcp:IssuerMetadata",
       "@context": {
-        "credentialIssuer": "cred:issuer",
+        "issuer": {
+          "@id": "cred:issuer",
+          "@type": "@id"
+        },
         "credentialsSupported": {
           "@id": "dcp:credentialsSupported",
           "@container": "@set"

--- a/artifacts/src/main/resources/issuance/credential-offer-message-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-offer-message-schema.json
@@ -15,7 +15,7 @@
         "@context": {
           "$ref": "https://w3id.org/dspace-dcp/v1.0/common/context-schema.json"
         },
-        "credentialIssuer": {
+        "issuer": {
           "type": "string"
         },
         "credentials": {
@@ -31,7 +31,7 @@
       },
       "required": [
         "@context",
-        "credentialIssuer",
+        "issuer",
         "credentials",
         "type"
       ]

--- a/artifacts/src/main/resources/issuance/example/credential-offer-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-offer-message.json
@@ -1,11 +1,9 @@
 {
   "@context": [
-    "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld",
-    "https://www.w3.org/2018/credentials/v1",
-    "https://www.w3.org/2018/credentials/examples/v1"
+    "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"
   ],
   "type": "CredentialOfferMessage",
-  "credentialIssuer": "issuer",
+  "issuer": "issuer",
   "credentials": [
     {
       "type": "CredentialObject",

--- a/artifacts/src/main/resources/issuance/example/issuer-metadata.json
+++ b/artifacts/src/main/resources/issuance/example/issuer-metadata.json
@@ -1,11 +1,9 @@
 {
   "@context": [
-    "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld",
-    "https://www.w3.org/2018/credentials/v1",
-    "https://www.w3.org/2018/credentials/examples/v1"
+    "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"
   ],
   "type": "IssuerMetadata",
-  "credentialIssuer": "did:web:issuer-url",
+  "issuer": "did:web:issuer-url",
   "credentialsSupported": [
     {
       "type": "CredentialObject",

--- a/artifacts/src/main/resources/issuance/issuer-metadata-schema.json
+++ b/artifacts/src/main/resources/issuance/issuer-metadata-schema.json
@@ -21,6 +21,9 @@
             "$ref": "https://w3id.org/dspace-dcp/v1.0/issuance/credential-object-schema.json#/definitions/CredentialObject"
           }
         },
+        "issuer": {
+          "type": "string"
+        },
         "type": {
           "type": "string",
           "const": "IssuerMetadata"
@@ -28,7 +31,7 @@
       },
       "required": [
         "@context",
-        "credentialIssuer",
+        "issuer",
         "credentialsSupported",
         "type"
       ]

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialOfferMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialOfferMessageSchemaTest.java
@@ -28,7 +28,7 @@ public class CredentialOfferMessageSchemaTest extends AbstractSchemaTest {
             {
               "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
               "type": "CredentialOfferMessage",
-              "credentialIssuer": "issuer",
+              "issuer": "issuer",
               "credentials": [%s]
             }""";
 
@@ -43,12 +43,12 @@ public class CredentialOfferMessageSchemaTest extends AbstractSchemaTest {
             {
               "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
               "type": "CredentialOfferMessage",
-              "credentialIssuer": "issuer"
+              "issuer": "issuer"
             }""";
 
     private static final String INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_TYPE_AND_CONTEXT = """
             {
-              "credentialIssuer": "issuer",
+              "issuer": "issuer",
               "credentials": [%s]
             }""";
 
@@ -58,7 +58,7 @@ public class CredentialOfferMessageSchemaTest extends AbstractSchemaTest {
 
         assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_CREDENTIAL_ISSUER.formatted(CREDENTIAL_OBJECT), JSON))
                 .extracting(this::errorExtractor)
-                .containsExactly(error("credentialIssuer", REQUIRED));
+                .containsExactly(error("issuer", REQUIRED));
 
 
         assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_CREDENTIALS, JSON))

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/IssuerMetadataSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/IssuerMetadataSchemaTest.java
@@ -28,7 +28,7 @@ public class IssuerMetadataSchemaTest extends AbstractSchemaTest {
             {
                 "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
                 "type": "IssuerMetadata",
-                "credentialIssuer": "did:web:issuer-url",
+                "issuer": "did:web:issuer-url",
                 "credentialsSupported": [%s]
             }""";
 
@@ -40,7 +40,7 @@ public class IssuerMetadataSchemaTest extends AbstractSchemaTest {
 
     private static final String INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_TYPE_AND_CONTEXT = """
             {
-              "credentialIssuer": "did:web:issuer-url",
+              "issuer": "did:web:issuer-url",
               "credentialsSupported": [%s]
             }""";
 
@@ -49,7 +49,7 @@ public class IssuerMetadataSchemaTest extends AbstractSchemaTest {
         assertThat(schema.validate(ISSUER_METADATA.formatted(CREDENTIAL_OBJECT), JSON)).isEmpty();
         assertThat(schema.validate(INVALID_ISSUER_METADATA, JSON))
                 .extracting(this::errorExtractor)
-                .containsExactly(error("credentialIssuer", REQUIRED), error("credentialsSupported", REQUIRED));
+                .containsExactly(error("issuer", REQUIRED), error("credentialsSupported", REQUIRED));
 
         assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_TYPE_AND_CONTEXT.formatted(CREDENTIAL_OBJECT), JSON))
                 .hasSize(2)

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -211,7 +211,7 @@ a [=Verifiable Credential=] offer.
 | **Schema**   | [JSON Schema](./resources/issuance/credential-offer-message-schema.json)                                           |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                                         |
 |              | - `type`: A string specifying the `CredentialOfferMessage` type                                                    |
-|              | - `credentialIssuer`:  The [=Credential Issuer=] DID                                                               |
+|              | - `issuer`:  The [=Credential Issuer=] DID                                                               |
 |              | - `credentials`: A JSON array, where every entry is a JSON object of type [[[#credentialobject]]] or a JSON string |
 
 If the `credentials` property entries are type string, the value MUST be one of the `id` values of an object in the
@@ -264,7 +264,7 @@ supported by the [=Credential Issuer=].
 | **Schema**   | [JSON Schema](./resources/issuance/issuer-metadata-schema.json)             |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). |
 |              | - `type`: A string specifying the `IssuerMetadata` type                     |
-|              | - `credentialIssuer`: A string containing the [=Credential Issuer=] DID     |
+|              | - `issuer`: A string containing the [=Credential Issuer=] DID     |
 | **Optional** | - `credentialsSupported`: A JSON array of [[[#credentialobject]]] elements  |
 
 The following is a non-normative example of a `IssuerMetadata` response object:


### PR DESCRIPTION

## WHAT

use directly the term `issuer` from VC data model instead of `credentialIssuer`

Closes #195 _

## How was the issue fixed?

_Briefly state why the change was necessary._

## More context

_List other areas that have changed but are not necessarily linked to the main feature. This could be naming changes,
bugs that were encountered and were fixed inline, etc._