### PR TITLE
feat: add optional credentialSubject property

### DIFF
--- a/artifacts/src/main/resources/context/dcp.jsonld
+++ b/artifacts/src/main/resources/context/dcp.jsonld
@@ -54,6 +54,10 @@
           "@id": "dcp:offerReason",
           "@type": "xsd:string"
         },
+        "clientSupply": {
+          "@id": "dcp:clientSupply",
+          "@type": "xsd:string"
+        },
         "bindingMethods": {
           "@id": "dcp:bindingMethods",
           "@type": "xsd:string",

--- a/artifacts/src/main/resources/issuance/credential-object-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-object-schema.json
@@ -21,6 +21,10 @@
         "offerReason": {
           "type": "string"
         },
+        "clientSupply": {
+          "type": "string",
+          "enum": ["required", "allowed", "forbidden"]
+        },
         "bindingMethods": {
           "type": "array",
           "items": {

--- a/artifacts/src/main/resources/issuance/credential-request-message-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-request-message-schema.json
@@ -31,6 +31,9 @@
               },
               "credentialType": {
                 "type": "string"
+              },
+              "credentialSubject": {
+                "type": "object"
               }
             },
             "required": [

--- a/artifacts/src/main/resources/issuance/example/credential-request-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-request-message.json
@@ -7,7 +7,12 @@
   "credentials": [
     {
       "credentialType": "MembershipCredential",
-      "format": "vcdm11_jwt"
+      "format": "vcdm11_jwt",
+      "credentialSubject": {
+        "id": "did:web:holder-corp.com:wallet:endpoint",
+        "joinedDataspace": "2025-04-01",
+        "specificId": "dataspace-identifier-1234"
+      }
     },
     {
       "credentialType": "OrganizationCredential",

--- a/artifacts/src/main/resources/issuance/example/credential-request-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-request-message.json
@@ -11,7 +11,7 @@
       "credentialSubject": {
         "id": "did:web:holder-corp.com:wallet:endpoint",
         "joinedDataspace": "2025-04-01",
-        "specificId": "dataspace-identifier-1234"
+        "dataspace-specific-id": "dataspace-identifier-1234"
       }
     },
     {

--- a/artifacts/src/main/resources/issuance/example/issuer-metadata.json
+++ b/artifacts/src/main/resources/issuance/example/issuer-metadata.json
@@ -9,6 +9,7 @@
       "type": "CredentialObject",
       "credentialType": "CompanyCredential",
       "offerReason": "reissue",
+      "clientSupply": "allowed",
       "bindingMethods": [
         "did:web"
       ],

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/fixtures/AbstractSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/fixtures/AbstractSchemaTest.java
@@ -19,6 +19,8 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.ValidationMessage;
 
+import java.util.Optional;
+
 import static com.networknt.schema.SpecVersion.VersionFlag.V202012;
 import static org.eclipse.dcp.schema.SchemaConstants.DCP_PREFIX;
 
@@ -46,7 +48,8 @@ public abstract class AbstractSchemaTest {
     }
 
     protected SchemaError errorExtractor(ValidationMessage validationMessage) {
-        return new SchemaError(validationMessage.getProperty(), validationMessage.getType());
+        return Optional.ofNullable(validationMessage.getProperty()).map(p->new SchemaError(p, validationMessage.getType()))
+                .orElseGet(() -> new SchemaError(validationMessage.getInstanceLocation().toString(), validationMessage.getType()));
     }
 
     protected SchemaError error(String property, String type) {

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialObjectSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialObjectSchemaTest.java
@@ -97,6 +97,41 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
                  }
             }""";
 
+    private static final String INVALID_CREDENTIAL_REQUEST_MESSAGE_INVALID_ENUMS = """
+             {
+                "type": "CredentialObject",
+                "credentialType": "VerifiableCredential",
+                "offerReason": "issue",
+                "clientSupply": "something",
+                "bindingMethods": [
+                  "did:web"
+                ],
+                "profiles": [
+                  "vc20-bssl/jwt", "vc10-sl2021/jwt"
+                ],
+                "issuancePolicy": {
+                   "id": "Scalable trust example",
+                   "input_descriptors": [
+                     {
+                       "id": "pd-id",
+                       "constraints": {
+                         "fields": [
+                           {
+                             "path": [
+                               "$.vc.type"
+                             ],
+                             "filter": {
+                               "type": "string",
+                               "pattern": "^AttestationCredential$"
+                             }
+                           }
+                         ]
+                       }
+                     }
+                   ]
+                 }
+            }""";
+
     @Test
     void verifySchema() {
         assertThat(schema.validate(CREDENTIAL_OBJECT, JSON)).isEmpty();
@@ -112,6 +147,11 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
                 .hasSize(1)
                 .extracting(this::errorExtractor)
                 .contains(error("type", REQUIRED));
+
+        assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_INVALID_ENUMS, JSON))
+                .hasSize(1)
+                .extracting(this::errorExtractor)
+                .contains(error("$.clientSupply", ENUM));
 
     }
 

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -102,9 +102,6 @@ Self-Issued ID Token to provide the pre-authorization code to the issuer.
 |              | - `holderPid`: A string corresponding to the request id on the Holder side type                                                                                                                                                                                                                                                                                              |
 |              | - `credentials`: a JSON array of objects, each containing a `format`, which is A JSON string <br/>that describes the format of the credential to be issued <br/>, a `type`: A JSON array of strings that specifies the VC type being requested and <br/>optionally a `credentialSubject` property with client-supplied data that the client requests the [=Issuer=] to sign. |
 
-When receiving a `credentials.credentialSubject` object with a `credentialSubject` property that the [=Issuer=] refuses
-to sign, the server MUST reject the issuance request altogether. 
-
 The following is a non-normative example of a `CredentialRequestMessage`:
 
 <aside class="example" title="CredentialRequestMessage">
@@ -118,12 +115,22 @@ example `"vcdm11_jwt"` or `"vcdm20_jose"`. The set of allowed values is implemen
 On successful receipt of the request, the [=Issuer Service=] MUST respond with a `201 CREATED` and the `Location`
 header set to the location of the request status ([[[#credential-request-status-api]]])
 
-The [=Issuer Service=] MAY respond with `401 Not Authorized` if the request is unauthorized or other `HTTP` status codes
-to indicate an exception.
+The [=Issuer Service=] MUST respond with `401 Not Authorized` if the request is unauthorized.
 
-If the request is approved, the issuer endpoint will send an acknowledgement to the client. When
+The [=Issuer Service=] MUST respond with `400 Bad Request` if the `credentials` array includes an object with a
+`credentialSubject` property that either violates or extends the corresponding `credentialSchema` of
+the [[[#credentialobject]]].
+
+The [=Issuer Service=] MUST respond with `501 Not Implemented` and an appropriate response body if it does not support
+the optional client-supplied `credentialSubject` property at all or for a specific `credentialType`.
+
+The [=Issuer Service=] MAY respond with `400 Bad Request` and an appropriate response body if it refuses to issue a
+Credential according to the client-supplied data in the `credentialSubject` property.
+
+If the request is approved, the issuer endpoint will send an acknowledgement to the client. The [=Issuer Service=] MAY
+still reject a request after initial acknowledgement and signify this via the [[[#credential-request-status-api]]].
 the [=Verifiable Credentials=] are ready, the [=Issuer Service=] will respond asynchronously with a write-request to the
-client's `Credential Service` using the Storage API defined in Section [[[#storage-api]]].
+client's `Credential Service` using the Storage API defined in Section [[[#storage-api]]]. 
 
 ## Storage API
 

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -130,7 +130,7 @@ Credential according to the client-supplied data in the `credentialSubject` prop
 If the request is approved, the issuer endpoint will send an acknowledgement to the client. The [=Issuer Service=] MAY
 still reject a request after initial acknowledgement and signify this via the [[[#credential-request-status-api]]].
 the [=Verifiable Credentials=] are ready, the [=Issuer Service=] will respond asynchronously with a write-request to the
-client's `Credential Service` using the Storage API defined in Section [[[#storage-api]]]. 
+client's `Credential Service` using the Storage API defined in Section [[[#storage-api]]].
 
 ## Storage API
 
@@ -237,17 +237,18 @@ The following is a non-normative example of a credential offer request:
 
 ### CredentialObject
 
-|              |                                                                                                                                                                                                                               |
-|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/issuance/credential-object-schema.json)                                                                                                                                                             |
-| **Required** | - `type`: A string specifying the `CredentialObject` type                                                                                                                                                                     |
-|              | - `credentialType`: A single string specifying type of credential being offered                                                                                                                                               |
-| **Optional** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). As the `credentialObject` is usually embedded, its context is provided by the enveloping object.                                                  |
-|              | - `bindingMethods`: An array of strings defining the key material that an issued credential is bound to                                                                                                                       |
-|              | - `credentialSchema`: A URL pointing to the credential schema of the object in a VC's `credentialSubject` property.                                                                                                           |
-|              | - `profiles`: An array of strings containing the aliases of the [profiles](#profiles-of-the-decentralized-claims-protocol), e.g. `"vc20-bssl/jwt"`                                                                            |
-|              | - `issuancePolicy`: A [presentation definition](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-definition) [[presentation-ex]] signifying the required [=Verifiable Presentation=] for issuance. |
-|              | - `offerReason`: A reason for the offer as a string. Valid values may include `reissue` and `proof-key-revocation`                                                                                                            |
+|              |                                                                                                                                                                                                                                     |
+|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Schema**   | [JSON Schema](./resources/issuance/credential-object-schema.json)                                                                                                                                                                   |
+| **Required** | - `type`: A string specifying the `CredentialObject` type                                                                                                                                                                           |
+|              | - `credentialType`: A single string specifying type of credential being offered                                                                                                                                                     |
+| **Optional** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). As the `credentialObject` is usually embedded, its context is provided by the enveloping object.                                                        |
+|              | - `bindingMethods`: An array of strings defining the key material that an issued credential is bound to                                                                                                                             |
+|              | - `credentialSchema`: A URL pointing to the credential schema of the object in a VC's `credentialSubject` property.                                                                                                                 |
+|              | - `clientSupply`: An enum indicating if an [=Issuer Service=] accepts client-supplied data in the `CredentialRequestMessage`'s `credentials.credentialSubject` property. Possible values are `required`, `allowed` and `forbidden`. |
+|              | - `profiles`: An array of strings containing the aliases of the [profiles](#profiles-of-the-decentralized-claims-protocol), e.g. `"vc20-bssl/jwt"`                                                                                  |
+|              | - `issuancePolicy`: A [presentation definition](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-definition) [[presentation-ex]] signifying the required [=Verifiable Presentation=] for issuance.       |
+|              | - `offerReason`: A reason for the offer as a string. Valid values may include `reissue` and `proof-key-revocation`                                                                                                                  |
 
 The following is a non-normative example of a `CredentialObject`:
 

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -76,7 +76,7 @@ the client's [=DID=] to obtain cryptographic material for validation and credent
 
 The ID Token MUST contain a `token` claim that is a bearer token granting write privileges for the
 requested [=Verifiable Credentials=] into the client's `Credential Service` as defined
-by[[[#verifiable-presentation-protocol]]]
+by [[[#verifiable-presentation-protocol]]]
 
 The bearer token MAY also be used by the [=Issuer Service=] to resolve [=Verifiable Presentations=] the client is
 required to hold for issuance of the requested [=Verifiable Credentials=].
@@ -94,13 +94,16 @@ Self-Issued ID Token to provide the pre-authorization code to the issuer.
 
 ### Credential Request Message
 
-|              |                                                                                                                                                                                                                                                  |
-|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/issuance/credential-request-message-schema.json)                                                                                                                                                                       |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                                                                                                                                                      |
-|              | - `type`: A string specifying the `CredentialRequestMessage` type                                                                                                                                                                                |
-|              | - `holderPid`: A string corresponding to the request id on the Holder side type                                                                                                                                                                  |
-|              | - `credentials`: a JSON array of objects, each containing a `format`, which is A JSON string <br/>that describes the format of the credential to be issued <br/>and a `type`: A JSON array of strings that specifies the VC type being requested |
+|              |                                                                                                                                                                                                                                                                                                                                                                              |
+|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Schema**   | [JSON Schema](./resources/issuance/credential-request-message-schema.json)                                                                                                                                                                                                                                                                                                   |
+| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                                                                                                                                                                                                                                                                                  |
+|              | - `type`: A string specifying the `CredentialRequestMessage` type                                                                                                                                                                                                                                                                                                            |
+|              | - `holderPid`: A string corresponding to the request id on the Holder side type                                                                                                                                                                                                                                                                                              |
+|              | - `credentials`: a JSON array of objects, each containing a `format`, which is A JSON string <br/>that describes the format of the credential to be issued <br/>, a `type`: A JSON array of strings that specifies the VC type being requested and <br/>optionally a `credentialSubject` property with client-supplied data that the client requests the [=Issuer=] to sign. |
+
+When receiving a `credentials.credentialSubject` object with a `credentialSubject` property that the [=Issuer=] refuses
+to sign, the server MUST reject the issuance request altogether. 
 
 The following is a non-normative example of a `CredentialRequestMessage`:
 
@@ -109,7 +112,7 @@ The following is a non-normative example of a `CredentialRequestMessage`:
     </pre>
 </aside> 
 
-the `credentials.format` string SHOULD clearly identify the data format and proof mechanism of the credential, for
+The `credentials.format` string SHOULD clearly identify the data format and proof mechanism of the credential, for
 example `"vcdm11_jwt"` or `"vcdm20_jose"`. The set of allowed values is implementation-specific.
 
 On successful receipt of the request, the [=Issuer Service=] MUST respond with a `201 CREATED` and the `Location`
@@ -211,7 +214,7 @@ a [=Verifiable Credential=] offer.
 | **Schema**   | [JSON Schema](./resources/issuance/credential-offer-message-schema.json)                                           |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                                         |
 |              | - `type`: A string specifying the `CredentialOfferMessage` type                                                    |
-|              | - `issuer`:  The [=Credential Issuer=] DID                                                               |
+|              | - `issuer`:  The [=Credential Issuer=] DID                                                                         |
 |              | - `credentials`: A JSON array, where every entry is a JSON object of type [[[#credentialobject]]] or a JSON string |
 
 If the `credentials` property entries are type string, the value MUST be one of the `id` values of an object in the
@@ -234,7 +237,7 @@ The following is a non-normative example of a credential offer request:
 |              | - `credentialType`: A single string specifying type of credential being offered                                                                                                                                               |
 | **Optional** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). As the `credentialObject` is usually embedded, its context is provided by the enveloping object.                                                  |
 |              | - `bindingMethods`: An array of strings defining the key material that an issued credential is bound to                                                                                                                       |
-|              | - `credentialSubject`: A URL pointing to the credential schema of the object in a VC's `credentialSubject` property.|
+|              | - `credentialSchema`: A URL pointing to the credential schema of the object in a VC's `credentialSubject` property.                                                                                                           |
 |              | - `profiles`: An array of strings containing the aliases of the [profiles](#profiles-of-the-decentralized-claims-protocol), e.g. `"vc20-bssl/jwt"`                                                                            |
 |              | - `issuancePolicy`: A [presentation definition](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-definition) [[presentation-ex]] signifying the required [=Verifiable Presentation=] for issuance. |
 |              | - `offerReason`: A reason for the offer as a string. Valid values may include `reissue` and `proof-key-revocation`                                                                                                            |
@@ -265,7 +268,7 @@ supported by the [=Credential Issuer=].
 | **Schema**   | [JSON Schema](./resources/issuance/issuer-metadata-schema.json)             |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). |
 |              | - `type`: A string specifying the `IssuerMetadata` type                     |
-|              | - `issuer`: A string containing the [=Credential Issuer=] DID     |
+|              | - `issuer`: A string containing the [=Credential Issuer=] DID               |
 | **Optional** | - `credentialsSupported`: A JSON array of [[[#credentialobject]]] elements  |
 
 The following is a non-normative example of a `IssuerMetadata` response object:

--- a/specifications/verifiable.presentation.protocol.md
+++ b/specifications/verifiable.presentation.protocol.md
@@ -192,15 +192,15 @@ when a `presentationDefinition`
 is provided in the [[[#presentation-query-message]]].
 
 ### Presentation Validation
-[=Verifier=] SHOULD validate the [=Verifiable-Presentation=] in the following manner:
+[=Verifier=] SHOULD validate the [=Verifiable Presentation=] in the following manner:
 
-1. The [=Verifier=] MUST assert that the [=Verifiable-Presentation=] is created either according to the `scope` or `presentationDefinition`
-2. The [=Verifier=] MUST validate the signature of the [=Verifiable-Presentation=] by using the key obtained from the resolved `VerificationMethod` of the [=Verifiable-Presentation=]. [=DID=] resolution is performed according to the [=DID=] Method specified in the [=DID=] part of the `VerificationMethod` of the [=Verifiable-Presentation=].
-3. The [=Verifier=] MUST validate that the `VerificationMethod` of the [=Verifiable-Presentation=] has the `Authentication` [Verification Relationship](https://www.w3.org/TR/did-1.0/#authentication)
-4. The [=Verifier=] MUST assert that the [=DID=] in the `VerificationMethod` of the [=Verifiable-Credential=] has the same value as the `issuer` of the [=Verifiable-Credential=]. 
-5. The [=Verifier=] MUST validate the signature of the [=Verifiable-Credential=] by using the key obtained from the resolved `VerificationMethod` of the [=Verifiable-Credential=]. [=DID=] resolution is performed according to the [=DID=] Method specified in the [=DID=] part of the `VerificationMethod` of the [=Verifiable-Presentation=].
-6. If the [=Verifiable-Credential=] contains a revocation mechanism, such as `StatusList2021`, the [=Verifier=] MUST validate the status of the [=Verifiable-Credential=] according to the revocation mechanism. 
-7. If the [=Verifiable-Presentation=] contains any claims regarding its `expiryDate` or `validity`, the [=Verifier=] MUST validate those claims.
-8. If any of the steps fail, the [=Verifier=] MUST consider the [=Verifiable-Presentation=] invalid. 
+1. The [=Verifier=] MUST assert that the [=Verifiable Presentation=] is created either according to the `scope` or `presentationDefinition`
+2. The [=Verifier=] MUST validate the signature of the [=Verifiable Presentation=] by using the key obtained from the resolved `VerificationMethod` of the [=Verifiable Presentation=]. [=DID=] resolution is performed according to the [=DID=] Method specified in the [=DID=] part of the `VerificationMethod` of the [=Verifiable Presentation=].
+3. The [=Verifier=] MUST validate that the `VerificationMethod` of the [=Verifiable Presentation=] has the `Authentication` [Verification Relationship](https://www.w3.org/TR/did-1.0/#authentication)
+4. The [=Verifier=] MUST assert that the [=DID=] in the `VerificationMethod` of the [=Verifiable Credential=] has the same value as the `issuer` of the [=Verifiable Credential=]. 
+5. The [=Verifier=] MUST validate the signature of the [=Verifiable Credential=] by using the key obtained from the resolved `VerificationMethod` of the [=Verifiable Credential=]. [=DID=] resolution is performed according to the [=DID=] Method specified in the [=DID=] part of the `VerificationMethod` of the [=Verifiable Presentation=].
+6. If the [=Verifiable Credential=] contains a revocation mechanism, such as `StatusList2021`, the [=Verifier=] MUST validate the status of the [=Verifiable Credential=] according to the revocation mechanism. 
+7. If the [=Verifiable Presentation=] contains any claims regarding its `expiryDate` or `validity`, the [=Verifier=] MUST validate those claims.
+8. If any of the steps fail, the [=Verifier=] MUST consider the [=Verifiable Presentation=] invalid. 
 
-Additionally, if the specific semantics of a data space and credentials require cryptographic holder binding, the [=Verifier=] MUST assert that the `credentialSubject.id` in the [=Verifiable-Credential=] and the [=DID=] part of the `VerificationMethod` of the [=Verifiable-Presentation=] have the same value.
+Additionally, if the specific semantics of a data space and credentials require cryptographic holder binding, the [=Verifier=] MUST assert that the `credentialSubject.id` in the [=Verifiable Credential=] and the [=DID=] part of the `VerificationMethod` of the [=Verifiable Presentation=] have the same value.


### PR DESCRIPTION
## WHAT

Adds to the CIP the possibility for a client to request credentials with specific claims. This allows to narrow the issuance protocol beyond the schema to the claim's actual value.

Closes #202

## How was the issue fixed?

Add additional property `credentialSubject` to `CredentialRequestMessage`.
