### PR TITLE
feat: add text for interrelation of DCP and DCP

### DIFF
--- a/specifications/dataspace.ecosystem.md
+++ b/specifications/dataspace.ecosystem.md
@@ -16,6 +16,12 @@ adheres to the model defined by the Dataspace Protocol [[dsp-base]]:
 - A <dfn>Credential Issuer</dfn> issues [=Verifiable Credentials=] used by [=participant agents=] to allow access to
   assets and verify usage control.
 
+## Interrelation to the Dataspace Protocol
+
+The Dataspace Protocol (DSP) [[dsp-base]] is designed as a layered protocol, which is independent of the 
+identity and trust systems used. The Decentralized Claims Protocol fills this gap by providing such an orthogonal 
+overlay for identity and trust in a decentralized manner.
+
 ## Systems
 
 ### Dataspace Governance Authority Systems

--- a/specifications/dataspace.ecosystem.md
+++ b/specifications/dataspace.ecosystem.md
@@ -19,7 +19,7 @@ adheres to the model defined by the Dataspace Protocol [[dsp-base]]:
 ## Interrelation to the Dataspace Protocol
 
 The Dataspace Protocol (DSP) [[dsp-base]] is designed as a layered protocol, which is independent of the 
-identity and trust systems used. The Decentralized Claims Protocol fills this gap by providing such an orthogonal 
+identity and trust system used. The Decentralized Claims Protocol fills this gap by providing such an orthogonal 
 overlay for identity and trust in a decentralized manner.
 
 ## Systems


### PR DESCRIPTION
## WHAT

add text for the interrelation of DSP/DCP in the specification 

Closes #119 

## How was the issue fixed?

the respective section was added

## More context

this text is only a short description for the specification. As mentioned in the issue, a more elaborate explanation will be provided in the best-practices.