### PR TITLE
fix: presentation exchange link

### DIFF
--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -236,7 +236,7 @@ The following is a non-normative example of a credential offer request:
 |              | - `bindingMethods`: An array of strings defining the key material that an issued credential is bound to                                                                                                                       |
 |              | - `credentialSchema`: A URL pointing to the credential schema of the object in a VC's `credentialSubject` property.                                                                                                           |
 |              | - `profiles`: An array of strings containing the aliases of the [profiles](#profiles-of-the-decentralized-claims-protocol), e.g. `"vc20-bssl/jwt"`                                                                            |
-|              | - `issuancePolicy`: A [presentation definition](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-definition) [[presentation-ex]] signifying the required [=Verifiable Presentation=] for issuance. |
+|              | - `issuancePolicy`: A [presentation definition](https://identity.foundation/presentation-exchange/spec/v2.1.1/#presentation-definition) [[presentation-ex]] signifying the required [=Verifiable Presentation=] for issuance. |
 |              | - `offerReason`: A reason for the offer as a string. Valid values may include `reissue` and `proof-key-revocation`                                                                                                            |
 
 The following is a non-normative example of a `CredentialObject`:

--- a/specifications/verifiable.presentation.protocol.md
+++ b/specifications/verifiable.presentation.protocol.md
@@ -125,7 +125,7 @@ The following are non-normative examples of the JSON body:
 An implementations MAY support the `presentationDefinition` parameter. If it does not, it MUST return
 `501 Not Implemented`. The `presentationDefinition` parameter contains a valid `Presentation Definition`
 according to
-the [Presentation Exchange Specification](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-definition).
+the [Presentation Exchange Specification](https://identity.foundation/presentation-exchange/spec/v2.1.1/#presentation-definition).
 The [=Credential Service=] will use the presentation definition to return a set of matching VPs in the format specified
 by the definition.
 
@@ -187,7 +187,7 @@ The following are non-normative examples of the JSON response body:
 
 Implementations that support the `presentationDefinition` parameter MUST include the `presentationSubmission` parameter
 in the [[[#presentation-response-message]]] with a
-valid [Presentation Submission](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-submission)
+valid [Presentation Submission](https://identity.foundation/presentation-exchange/spec/v2.1.1/#presentation-submission)
 when a `presentationDefinition`
 is provided in the [[[#presentation-query-message]]].
 

--- a/specifications/verifiable.presentation.protocol.md
+++ b/specifications/verifiable.presentation.protocol.md
@@ -122,7 +122,7 @@ The following are non-normative examples of the JSON body:
 
 #### Presentation Definitions
 
-An implementations MAY support the `presentationDefinition` parameter. If it does not, it MUST return
+An implementation MAY support the `presentationDefinition` parameter. If it does not, it MUST return
 `501 Not Implemented`. The `presentationDefinition` parameter contains a valid `Presentation Definition`
 according to
 the [Presentation Exchange Specification](https://identity.foundation/presentation-exchange/spec/v2.1.1/#presentation-definition).


### PR DESCRIPTION
## WHAT

Update the links for the Presentation Exchange specification.  

Closes #212 

## How was the issue fixed?

Update from v2.0.0 to v2.1.1

## More context

Small typo on the "Presentation Definitions" section. An implementations -> An implementation