### PR TITLE
feat: add ID to CredentialObject

### DIFF
--- a/artifacts/src/main/resources/issuance/credential-object-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-object-schema.json
@@ -12,6 +12,10 @@
     "CredentialObject": {
       "type": "object",
       "properties": {
+        "id": {
+          "type": "string",
+          "format": "uri"
+        },
         "credentialType": {
           "type": "string"
         },
@@ -43,6 +47,7 @@
         }
       },
       "required": [
+        "id",
         "credentialType",
         "offerReason",
         "bindingMethods",

--- a/artifacts/src/main/resources/issuance/credential-request-message-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-request-message-schema.json
@@ -26,12 +26,12 @@
           "items": {
             "type": "object",
             "properties": {
-              "credentialObjectId": {
+              "id": {
                 "type": "string"
               }
             },
             "required": [
-              "credentialObjectId"
+              "id"
             ]
           }
         }

--- a/artifacts/src/main/resources/issuance/credential-request-message-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-request-message-schema.json
@@ -28,10 +28,14 @@
             "properties": {
               "id": {
                 "type": "string"
+              },
+              "format": {
+                "type": "string"
               }
             },
             "required": [
-              "id"
+              "id",
+              "format"
             ]
           }
         }

--- a/artifacts/src/main/resources/issuance/credential-request-message-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-request-message-schema.json
@@ -24,7 +24,15 @@
         "credentials": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "object",
+            "properties": {
+              "credentialObjectId": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "credentialObjectId"
+            ]
           }
         }
       },

--- a/artifacts/src/main/resources/issuance/credential-request-message-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-request-message-schema.json
@@ -24,19 +24,7 @@
         "credentials": {
           "type": "array",
           "items": {
-            "type": "object",
-            "properties": {
-              "format": {
-                "type": "string"
-              },
-              "credentialType": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "credentialType",
-              "format"
-            ]
+            "type": "string"
           }
         }
       },

--- a/artifacts/src/main/resources/issuance/example/credential-object.json
+++ b/artifacts/src/main/resources/issuance/example/credential-object.json
@@ -2,6 +2,7 @@
   "@context": [
     "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"
   ],
+  "id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
   "type": "CredentialObject",
   "credentialType": "CompanyCredential",
   "credentialSchema": "https://example.com/credentials/credentialSchema",

--- a/artifacts/src/main/resources/issuance/example/credential-offer-message-with-ids.json
+++ b/artifacts/src/main/resources/issuance/example/credential-offer-message-with-ids.json
@@ -2,8 +2,8 @@
   "@context": [
     "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"
   ],
-  "type": "CredentialRequestMessage",
-  "holderPid": "holderPid",
+  "type": "CredentialOfferMessage",
+  "issuer": "issuer",
   "credentials": [
     "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
     "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"

--- a/artifacts/src/main/resources/issuance/example/credential-offer-message-with-ids.json
+++ b/artifacts/src/main/resources/issuance/example/credential-offer-message-with-ids.json
@@ -5,7 +5,7 @@
   "type": "CredentialOfferMessage",
   "issuer": "issuer",
   "credentials": [
-    { "credentialObjectId": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1" },
-    { "credentialObjectId":  "c0f81e68-6d35-4f9d-bc04-51e511b2e46c" }
+    { "{ "id": "": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1" },
+    { "{ "id": "":  "c0f81e68-6d35-4f9d-bc04-51e511b2e46c" }
   ]
 }

--- a/artifacts/src/main/resources/issuance/example/credential-offer-message-with-ids.json
+++ b/artifacts/src/main/resources/issuance/example/credential-offer-message-with-ids.json
@@ -5,7 +5,7 @@
   "type": "CredentialOfferMessage",
   "issuer": "issuer",
   "credentials": [
-    "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
-    "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"
+    { "credentialObjectId": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1" },
+    { "credentialObjectId":  "c0f81e68-6d35-4f9d-bc04-51e511b2e46c" }
   ]
 }

--- a/artifacts/src/main/resources/issuance/example/credential-offer-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-offer-message.json
@@ -6,6 +6,7 @@
   "issuer": "issuer",
   "credentials": [
     {
+      "id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
       "type": "CredentialObject",
       "credentialType": "CompanyCredential",
       "offerReason": "reissue",

--- a/artifacts/src/main/resources/issuance/example/credential-request-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-request-message.json
@@ -5,7 +5,11 @@
   "type": "CredentialRequestMessage",
   "holderPid": "holderPid",
   "credentials": [
-    "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
-    "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"
+    {
+      "credentialObjectId": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"
+    },
+    {
+      "credentialObjectId": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"
+    }
   ]
 }

--- a/artifacts/src/main/resources/issuance/example/credential-request-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-request-message.json
@@ -6,10 +6,10 @@
   "holderPid": "holderPid",
   "credentials": [
     {
-      "credentialObjectId": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"
+      "id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"
     },
     {
-      "credentialObjectId": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"
+      "id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"
     }
   ]
 }

--- a/artifacts/src/main/resources/issuance/example/credential-request-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-request-message.json
@@ -6,10 +6,12 @@
   "holderPid": "holderPid",
   "credentials": [
     {
-      "id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"
+      "id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
+      "format": "vcdm11_jwt"
     },
     {
-      "id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"
+      "id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c",
+      "format": "vcdm20_jose"
     }
   ]
 }

--- a/artifacts/src/main/resources/issuance/example/issuer-metadata.json
+++ b/artifacts/src/main/resources/issuance/example/issuer-metadata.json
@@ -6,6 +6,7 @@
   "issuer": "did:web:issuer-url",
   "credentialsSupported": [
     {
+      "id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
       "type": "CredentialObject",
       "credentialType": "CompanyCredential",
       "offerReason": "reissue",

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialObjectSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialObjectSchemaTest.java
@@ -25,6 +25,7 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
 
     public static final String CREDENTIAL_OBJECT = """
             {
+                "id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
                 "type": "CredentialObject",
                 "credentialType": "VerifiableCredential",
                 "credentialSchema": "https://example.com/credentials/credentialSchema",
@@ -66,6 +67,7 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
 
     private static final String INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_TYPE_AND_CONTEXT = """
              {
+                "id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
                 "credentialType": "VerifiableCredential",
                 "offerReason": "reissue",
                 "bindingMethods": [
@@ -102,7 +104,9 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
         assertThat(schema.validate(CREDENTIAL_OBJECT, JSON)).isEmpty();
         assertThat(schema.validate(INVALID_CREDENTIAL_OBJECT, JSON))
                 .extracting(this::errorExtractor)
-                .containsExactly(error("credentialType", REQUIRED),
+                .containsExactly(
+                        error("id", REQUIRED),
+                        error("credentialType", REQUIRED),
                         error("offerReason", REQUIRED),
                         error("bindingMethods", REQUIRED),
                         error("profiles", REQUIRED),

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialOfferMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialOfferMessageSchemaTest.java
@@ -22,7 +22,7 @@ import static com.networknt.schema.InputFormat.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dcp.schema.issuance.CredentialObjectSchemaTest.CREDENTIAL_OBJECT;
 
-public class CredentialOfferMessageSchemaTest extends AbstractSchemaTest {
+public class  CredentialOfferMessageSchemaTest extends AbstractSchemaTest {
 
     private static final String CREDENTIAL_OFFER_MESSAGE = """
             {

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialRequestMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialRequestMessageSchemaTest.java
@@ -29,8 +29,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "type": "CredentialRequestMessage",
               "holderPid": "holderPid",
               "credentials": [
-                 "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
-                 "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"
+                 {"credentialObjectId": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"},
+                 {"credentialObjectId": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"}
               ]
             }""";
 
@@ -39,8 +39,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
               "type": "CredentialRequestMessage",
               "credentials": [
-                  "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
-                  "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"
+                 {"credentialObjectId": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"},
+                 {"credentialObjectId": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"}
               ]
             }""";
 
@@ -50,8 +50,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "type": "CredentialRequestMessage",
               "holderPid": "holderPid",
               "credentials": [
-                  42069,
-                  4711
+                  { "credentialObjectId": 42069 },
+                  { "credentialObjectId": 4711 }
               ]
             }""";
 
@@ -69,8 +69,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
             {
               "holderPid": "holderPid",
               "credentials": [
-                  "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
-                  "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"
+                 {"credentialObjectId": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"},
+                 {"credentialObjectId": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"}
               ]
             }""";
 

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialRequestMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialRequestMessageSchemaTest.java
@@ -29,18 +29,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "type": "CredentialRequestMessage",
               "holderPid": "holderPid",
               "credentials": [
-                 {
-                   "credentialType": "MembershipCredential",
-                   "format": "vcdm11_jwt"
-                 },
-                 {
-                   "credentialType": "OrganizationCredential",
-                   "format": "vcdm11_ld"
-                 },
-                 {
-                   "credentialType": "Iso9001Credential",
-                   "format": "vcdm20_jose"
-                 }
+                 "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
+                 "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"
               ]
             }""";
 
@@ -49,50 +39,29 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
               "type": "CredentialRequestMessage",
               "credentials": [
-                 {
-                   "credentialType": "MembershipCredential",
-                   "format": "vcdm11_jwt"
-                 },
-                 {
-                   "credentialType": "OrganizationCredential",
-                   "format": "vcdm11_ld"
-                 },
-                 {
-                   "credentialType": "Iso9001Credential",
-                   "format": "vcdm20_jose"
-                 }
+                  "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
+                  "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"
               ]
             }""";
 
-    private static final String INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_FORMAT = """
+    private static final String INVALID_CREDENTIAL_REQUEST_MESSAGE_ID_NOT_STRING = """
             {
               "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
               "type": "CredentialRequestMessage",
               "holderPid": "holderPid",
               "credentials": [
-                 {
-                   "credentialType": "MembershipCredential"
-                 },
-                 {
-                   "credentialType": "OrganizationCredential",
-                   "format": "vcdm11_ld"
-                 },
-                 {
-                   "credentialType": "Iso9001Credential",
-                   "format": "vcdm20_jose"
-                 }
+                  42069,
+                  4711
               ]
             }""";
 
-    private static final String INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_CREDENTIAL_TYPE = """
+
+    private static final String INVALID_CREDENTIAL_REQUEST_MESSAGE_EMPTY_ARRAY = """
             {
               "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
               "type": "CredentialRequestMessage",
               "holderPid": "holderPid",
               "credentials": [
-                 {
-                   "format": "vcdm11_ld"
-                 }
               ]
             }""";
 
@@ -100,10 +69,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
             {
               "holderPid": "holderPid",
               "credentials": [
-                 {
-                   "credentialType": "MembershipCredential",
-                   "format": "vcdm11_jwt"
-                 }
+                  "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
+                  "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"
               ]
             }""";
 
@@ -111,18 +78,16 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
     @Test
     void verifySchema() {
         assertThat(schema.validate(CREDENTIAL_REQUEST_MESSAGE, JSON)).isEmpty();
+        assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_EMPTY_ARRAY, JSON))
+                .isEmpty();
 
         assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_HOLDER_REQUEST_ID, JSON))
                 .extracting(this::errorExtractor)
                 .containsExactly(error("holderPid", REQUIRED));
 
-        assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_FORMAT, JSON))
+        assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_ID_NOT_STRING, JSON))
                 .extracting(this::errorExtractor)
-                .containsExactly(error("format", REQUIRED));
-
-        assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_CREDENTIAL_TYPE, JSON))
-                .extracting(this::errorExtractor)
-                .containsExactly(error("credentialType", REQUIRED));
+                .containsExactly(error(null, TYPE), error(null, TYPE));
 
         assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_TYPE_AND_CONTEXT, JSON))
                 .hasSize(2)

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialRequestMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialRequestMessageSchemaTest.java
@@ -29,8 +29,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "type": "CredentialRequestMessage",
               "holderPid": "holderPid",
               "credentials": [
-                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"},
-                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"}
+                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1", "format": "vcdm20_jose"},
+                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c", "format": "vcdm11_jwt"}
               ]
             }""";
 
@@ -39,8 +39,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
               "type": "CredentialRequestMessage",
               "credentials": [
-                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"},
-                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"}
+                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1", "format": "vcdm20_jose"},
+                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c", "format": "vcdm11_jwt"}
               ]
             }""";
 
@@ -50,8 +50,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "type": "CredentialRequestMessage",
               "holderPid": "holderPid",
               "credentials": [
-                  { "id": 42069 },
-                  { "id": 4711 }
+                  { "id": 42069, "format": "vcdm20_jose" },
+                  { "id": 4711, "format": "vcdm11_jwt" }
               ]
             }""";
 
@@ -69,8 +69,19 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
             {
               "holderPid": "holderPid",
               "credentials": [
-                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"},
-                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"}
+                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1", "format": "vcdm20_jose"},
+                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c", "format": "vcdm11_jwt"}
+              ]
+            }""";
+
+    private static final String CREDENTIAL_REQUEST_MESSAGE_NO_FORMAT = """
+            {
+              "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
+              "type": "CredentialRequestMessage",
+              "holderPid": "holderPid",
+              "credentials": [
+                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1" },
+                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c", "format": "vcdm11_jwt"}
               ]
             }""";
 
@@ -94,6 +105,10 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
                 .extracting(this::errorExtractor)
                 .contains(error("type", REQUIRED), error("@context", REQUIRED));
 
+        assertThat(schema.validate(CREDENTIAL_REQUEST_MESSAGE_NO_FORMAT, JSON))
+                .hasSize(1)
+                .extracting(this::errorExtractor)
+                .contains(error("format", REQUIRED));
 
     }
 

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialRequestMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialRequestMessageSchemaTest.java
@@ -29,8 +29,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "type": "CredentialRequestMessage",
               "holderPid": "holderPid",
               "credentials": [
-                 {"credentialObjectId": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"},
-                 {"credentialObjectId": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"}
+                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"},
+                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"}
               ]
             }""";
 
@@ -39,8 +39,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
               "type": "CredentialRequestMessage",
               "credentials": [
-                 {"credentialObjectId": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"},
-                 {"credentialObjectId": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"}
+                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"},
+                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"}
               ]
             }""";
 
@@ -50,8 +50,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "type": "CredentialRequestMessage",
               "holderPid": "holderPid",
               "credentials": [
-                  { "credentialObjectId": 42069 },
-                  { "credentialObjectId": 4711 }
+                  { "id": 42069 },
+                  { "id": 4711 }
               ]
             }""";
 
@@ -69,8 +69,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
             {
               "holderPid": "holderPid",
               "credentials": [
-                 {"credentialObjectId": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"},
-                 {"credentialObjectId": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"}
+                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"},
+                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"}
               ]
             }""";
 

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -211,7 +211,7 @@ a [=Verifiable Credential=] offer.
 | **Schema**   | [JSON Schema](./resources/issuance/credential-offer-message-schema.json)                                           |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                                         |
 |              | - `type`: A string specifying the `CredentialOfferMessage` type                                                    |
-|              | - `issuer`:  The [=Credential Issuer=] DID                                                               |
+|              | - `issuer`:  The [=Credential Issuer=] DID                                                                         |
 |              | - `credentials`: A JSON array, where every entry is a JSON object of type [[[#credentialobject]]] or a JSON string |
 
 If the `credentials` property entries are type string, the value MUST be one of the `id` values of an object in the
@@ -225,6 +225,11 @@ The following is a non-normative example of a credential offer request:
     </pre>
 </aside>   
 
+<aside class="example" title="CredentialOfferMessage with IDs">
+    <pre class="json" data-include="./resources/issuance/example/credential-offer-message-ids.json">
+    </pre>
+</aside>
+
 ### CredentialObject
 
 |              |                                                                                                                                                                                                                               |
@@ -232,6 +237,7 @@ The following is a non-normative example of a credential offer request:
 | **Schema**   | [JSON Schema](./resources/issuance/credential-object-schema.json)                                                                                                                                                             |
 | **Required** | - `type`: A string specifying the `CredentialObject` type                                                                                                                                                                     |
 |              | - `credentialType`: A single string specifying type of credential being offered                                                                                                                                               |
+|              | - `id`: a string defining a unique, stable identifier for this `CredentialObject`                                                                                                                                             |
 | **Optional** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). As the `credentialObject` is usually embedded, its context is provided by the enveloping object.                                                  |
 |              | - `bindingMethods`: An array of strings defining the key material that an issued credential is bound to                                                                                                                       |
 |              | - `credentialSchema`: A URL pointing to the credential schema of the object in a VC's `credentialSubject` property.                                                                                                           |
@@ -265,7 +271,7 @@ supported by the [=Credential Issuer=].
 | **Schema**   | [JSON Schema](./resources/issuance/issuer-metadata-schema.json)             |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). |
 |              | - `type`: A string specifying the `IssuerMetadata` type                     |
-|              | - `issuer`: A string containing the [=Credential Issuer=] DID     |
+|              | - `issuer`: A string containing the [=Credential Issuer=] DID               |
 | **Optional** | - `credentialsSupported`: A JSON array of [[[#credentialobject]]] elements  |
 
 The following is a non-normative example of a `IssuerMetadata` response object:

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -94,13 +94,13 @@ Self-Issued ID Token to provide the pre-authorization code to the issuer.
 
 ### Credential Request Message
 
-|              |                                                                                                                                                                                                                                                  |
-|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/issuance/credential-request-message-schema.json)                                                                                                                                                                       |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                                                                                                                                                      |
-|              | - `type`: A string specifying the `CredentialRequestMessage` type                                                                                                                                                                                |
-|              | - `holderPid`: A string corresponding to the request id on the Holder side type                                                                                                                                                                  |
-|              | - `credentials`: a JSON array of objects, each containing a `format`, which is A JSON string <br/>that describes the format of the credential to be issued <br/>and a `type`: A JSON array of strings that specifies the VC type being requested |
+|              |                                                                                  |
+|--------------|----------------------------------------------------------------------------------|
+| **Schema**   | [JSON Schema](./resources/issuance/credential-request-message-schema.json)       |
+| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).      |
+|              | - `type`: A string specifying the `CredentialRequestMessage` type                |
+|              | - `holderPid`: A string corresponding to the request id on the Holder side type  |
+|              | - `credentials`: an array of strings, each referencing a [[[#credentialobject]]] |
 
 The following is a non-normative example of a `CredentialRequestMessage`:
 
@@ -109,8 +109,8 @@ The following is a non-normative example of a `CredentialRequestMessage`:
     </pre>
 </aside> 
 
-the `credentials.format` string SHOULD clearly identify the data format and proof mechanism of the credential, for
-example `"vcdm11_jwt"` or `"vcdm20_jose"`. The set of allowed values is implementation-specific.
+Each IDs in the `credentials` array MUST be one of the `id` values of an object in the `credentialsSupported` returned from the 
+[[[#issuer-metadata-api]]]. When processing, the [=Issuer Service=] MUST resolve this string value to the respective object.
 
 On successful receipt of the request, the [=Issuer Service=] MUST respond with a `201 CREATED` and the `Location`
 header set to the location of the request status ([[[#credential-request-status-api]]])


### PR DESCRIPTION
## WHAT

adds an `id` property to the `CredentialObject` as well as simplifies the `CredentialRequestMesssage`

Closes #214

## How was the issue fixed?

`id` property was added

## More context

- the `CredentialRequestMessage` was simplified to only contain an array of IDs

