### PR TITLE
chore: make CredentialObject.profile singular

### DIFF
--- a/artifacts/src/main/resources/context/dcp.jsonld
+++ b/artifacts/src/main/resources/context/dcp.jsonld
@@ -59,10 +59,9 @@
           "@type": "xsd:string",
           "@container": "@set"
         },
-        "profiles": {
-          "@id": "dcp:profiles",
-          "@type": "xsd:string",
-          "@container": "@set"
+        "profile": {
+          "@id": "dcp:profile",
+          "@type": "xsd:string"
         },
         "issuancePolicy": {
           "@id": "dcp:issuancePolicy",

--- a/artifacts/src/main/resources/issuance/credential-object-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-object-schema.json
@@ -31,11 +31,8 @@
             "type": "string"
           }
         },
-        "profiles": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "profile": {
+          "type": "string"
         },
         "issuancePolicy": {
           "type": "object",
@@ -51,7 +48,7 @@
         "credentialType",
         "offerReason",
         "bindingMethods",
-        "profiles",
+        "profile",
         "issuancePolicy",
         "type"
       ]

--- a/artifacts/src/main/resources/issuance/credential-request-message-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-request-message-schema.json
@@ -28,14 +28,10 @@
             "properties": {
               "id": {
                 "type": "string"
-              },
-              "format": {
-                "type": "string"
               }
             },
             "required": [
-              "id",
-              "format"
+              "id"
             ]
           }
         }

--- a/artifacts/src/main/resources/issuance/example/credential-object.json
+++ b/artifacts/src/main/resources/issuance/example/credential-object.json
@@ -10,11 +10,7 @@
   "bindingMethods": [
     "did:web"
   ],
-  "profiles": [
-    "vc20-bssl/jwt",
-    "vc10-sl2021/jwt",
-    "..."
-  ],
+  "profile": "vc20-bssl/jwt",
   "issuancePolicy": {
     "id": "Scalable trust example",
     "input_descriptors": [

--- a/artifacts/src/main/resources/issuance/example/credential-offer-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-offer-message.json
@@ -13,11 +13,7 @@
       "bindingMethods": [
         "did:web"
       ],
-      "profiles": [
-        "vc20-bssl/jwt",
-        "vc10-sl2021/jwt",
-        "..."
-      ],
+      "profile": "vc10-sl2021/jwt",
       "issuancePolicy": {
         "id": "Scalable trust example",
         "input_descriptors": [

--- a/artifacts/src/main/resources/issuance/example/credential-request-message.json
+++ b/artifacts/src/main/resources/issuance/example/credential-request-message.json
@@ -6,12 +6,10 @@
   "holderPid": "holderPid",
   "credentials": [
     {
-      "id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
-      "format": "vcdm11_jwt"
+      "id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1"
     },
     {
-      "id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c",
-      "format": "vcdm20_jose"
+      "id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c"
     }
   ]
 }

--- a/artifacts/src/main/resources/issuance/example/issuer-metadata.json
+++ b/artifacts/src/main/resources/issuance/example/issuer-metadata.json
@@ -13,11 +13,7 @@
       "bindingMethods": [
         "did:web"
       ],
-      "profiles": [
-        "vc20-bssl/jwt",
-        "vc10-sl2021/jwt",
-        "..."
-      ],
+      "profile": "vc10-sl2021/jwt",
       "issuancePolicy": {
         "id": "Scalable trust example",
         "input_descriptors": [

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialObjectSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialObjectSchemaTest.java
@@ -33,9 +33,7 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
                 "bindingMethods": [
                   "did:web"
                 ],
-                "profiles": [
-                  "vc20-bssl/jwt"
-                ],
+                "profile": "vc20-bssl/jwt",
                 "issuancePolicy": {
                   "id": "Scalable trust example",
                   "input_descriptors": [
@@ -73,9 +71,7 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
                 "bindingMethods": [
                   "did:web"
                 ],
-                "profiles": [
-                  "vc20-bssl/jwt", "vc10-sl2021/jwt"
-                ],
+                "profile":"vc20-bssl/jwt",
                 "issuancePolicy": {
                    "id": "Scalable trust example",
                    "input_descriptors": [
@@ -109,7 +105,7 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
                         error("credentialType", REQUIRED),
                         error("offerReason", REQUIRED),
                         error("bindingMethods", REQUIRED),
-                        error("profiles", REQUIRED),
+                        error("profile", REQUIRED),
                         error("issuancePolicy", REQUIRED));
 
         assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_TYPE_AND_CONTEXT, JSON))

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialRequestMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialRequestMessageSchemaTest.java
@@ -29,8 +29,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "type": "CredentialRequestMessage",
               "holderPid": "holderPid",
               "credentials": [
-                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1", "format": "vcdm20_jose"},
-                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c", "format": "vcdm11_jwt"}
+                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1" },
+                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c" }
               ]
             }""";
 
@@ -39,8 +39,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
               "type": "CredentialRequestMessage",
               "credentials": [
-                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1", "format": "vcdm20_jose"},
-                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c", "format": "vcdm11_jwt"}
+                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1" },
+                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c" }
               ]
             }""";
 
@@ -50,8 +50,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "type": "CredentialRequestMessage",
               "holderPid": "holderPid",
               "credentials": [
-                  { "id": 42069, "format": "vcdm20_jose" },
-                  { "id": 4711, "format": "vcdm11_jwt" }
+                  { "id": 42069 },
+                  { "id": 4711 }
               ]
             }""";
 
@@ -69,8 +69,8 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
             {
               "holderPid": "holderPid",
               "credentials": [
-                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1", "format": "vcdm20_jose"},
-                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c", "format": "vcdm11_jwt"}
+                 {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1" },
+                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c" }
               ]
             }""";
 
@@ -81,7 +81,7 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
               "holderPid": "holderPid",
               "credentials": [
                  {"id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1" },
-                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c", "format": "vcdm11_jwt"}
+                 {"id": "c0f81e68-6d35-4f9d-bc04-51e511b2e46c" }
               ]
             }""";
 
@@ -104,11 +104,6 @@ public class CredentialRequestMessageSchemaTest extends AbstractSchemaTest {
                 .hasSize(2)
                 .extracting(this::errorExtractor)
                 .contains(error("type", REQUIRED), error("@context", REQUIRED));
-
-        assertThat(schema.validate(CREDENTIAL_REQUEST_MESSAGE_NO_FORMAT, JSON))
-                .hasSize(1)
-                .extracting(this::errorExtractor)
-                .contains(error("format", REQUIRED));
 
     }
 

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -241,7 +241,7 @@ The following is a non-normative example of a credential offer request:
 | **Optional** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). As the `credentialObject` is usually embedded, its context is provided by the enveloping object.                                                  |
 |              | - `bindingMethods`: An array of strings defining the key material that an issued credential is bound to                                                                                                                       |
 |              | - `credentialSchema`: A URL pointing to the credential schema of the object in a VC's `credentialSubject` property.                                                                                                           |
-|              | - `profiles`: An array of strings containing the aliases of the [profiles](#profiles-of-the-decentralized-claims-protocol), e.g. `"vc20-bssl/jwt"`                                                                            |
+|              | - `profile`: An string containing the alias of the [profiles](#profiles-of-the-decentralized-claims-protocol), e.g. `"vc20-bssl/jwt"`                                                                                         |
 |              | - `issuancePolicy`: A [presentation definition](https://identity.foundation/presentation-exchange/spec/v2.1.1/#presentation-definition) [[presentation-ex]] signifying the required [=Verifiable Presentation=] for issuance. |
 |              | - `offerReason`: A reason for the offer as a string. Valid values may include `reissue` and `proof-key-revocation`                                                                                                            |
 


### PR DESCRIPTION
## WHAT

This PR achieves two things:

- it changes `CredentialObject.profiles` -> `.profile` (singular)
- it removes `CredentialRequestMessage.credentials.format` as it is not necessary anymore

Closes #214

## How was the issue fixed?

.

## More context

_List other areas that have changed but are not necessarily linked to the main feature. This could be naming changes,
bugs that were encountered and were fixed inline, etc._

