### PR TITLE
fix: credential exchange flows typos

### DIFF
--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -16,9 +16,9 @@ issue a [=Verifiable Credential=]:
    of scopes that define the [=Verifiable Credentials=] the client wants the [=Issuer Service=] to provide. This set of
    scopes is determined out of band and may be derived from metadata the [=Credential Issuer=] has previously made
    available to the client.
-2. The [=Secure Token Service=] responds with an access token a that may be in `token` claim a [=Self-Issued ID Token=].
-   The access token can be used by the [=Issuer Service=] to write requested [=Verifiable Credentials=]
-   to the client's [=Credential Service=].
+2. The [=Secure Token Service=] responds with an access token, which may be included in the `token` claim of the
+   [=Self-Issued ID Token=]. The access token can be used by the [=Issuer Service=] to write requested 
+   [=Verifiable Credentials=] to the client's [=Credential Service=].
 3. The client makes a request to the [=Issuer Service=] for one or more [=Verifiable Credentials=] and includes
    a [=Self-Issued ID Token=] containing the access token.
 4. The [=Issuer Service=] resolves the client [=DID=] based on the value of the [=Self-Issued ID Token=] `sub` claim.

--- a/specifications/verifiable.presentation.protocol.md
+++ b/specifications/verifiable.presentation.protocol.md
@@ -26,9 +26,9 @@ The following sequence diagram depicts a non-normative flow where a client inter
    of scopes that define the [=Verifiable Credentials=] the client wants the [=Verifier=] to have access to. This set of
    scopes is determined out of band and may be derived from metadata the [=verifier=] has previously made available to
    the client.
-2. The [=Secure Token Service=] responds with an access token a that may be in `token` claim a [=Self-Issued ID Token=].
-   The access token can be used by the verifier to request [=Verifiable Credentials=] from the client's
-   [=Credential Service=].
+2. The [=Secure Token Service=] responds with an access token, which may be included in the `token` claim of the
+   [=Self-Issued ID Token=]. The access token can be used by the verifier to request [=Verifiable Credentials=] from the
+   client's [=Credential Service=].
 3. The client makes a request to the [=Verifier=] for a protected resource and includes a [=Self-Issued ID Token=]
    containing the access token.
 4. The [=Verifier=] resolves the client [=DID=] based on the value of the [=Self-Issued ID Token=] `sub` claim.


### PR DESCRIPTION
## WHAT

Corrects a typos / grammatical errors in a bullet point shared by the presented credential exchange flows (credential presentation flow and issuance flow)

Closes #216

## How was the issue fixed?

As presented in #216, by changing:

> The Secure Token Service responds with an access token a that may be in token claim a Self-Issued ID Token.

To:

> The Secure Token Service responds with an access token, which may be included in the token claim of the Self-Issued ID Token.
