### PR TITLE
fix: typos and sugestions issuance protocol

### DIFF
--- a/specifications/base.protocol.md
+++ b/specifications/base.protocol.md
@@ -42,28 +42,28 @@ The following claims MUST be included in the Self-Issued ID Token:
 
 A Self-Issued ID Token MAY contain an access token as a `token` claim that can be used by the [=Verifier=] to
 obtain [=Verifiable Presentations=] from the participant's [=Credential Service=]. The format of the `token` is
-implementation-specific and therefore should be treated as an opaque string by the [=Verifier=].
+implementation-specific and therefore SHOULD be treated as an opaque string by the [=Verifier=].
 
 ### Obtaining Self-Issued ID Tokens
 
 _This section is non-normative._
 
-How a Self-Issued ID token is obtained from a [=Secure Token Service=] is implementation-specific. An [=STS=] may
+How a Self-Issued ID token is obtained from a [=Secure Token Service=] is implementation-specific. An [=STS=] MAY
 support a
 variety of APIs, including OAuth 2.
 
 #### Using the OAuth 2 Client Credential Grant
 
-A Self-Issued ID Token may be obtained by executing a Client Credential Grant as defined in [[[?rfc6749]]]
+A Self-Issued ID Token MAY be obtained by executing a Client Credential Grant as defined in [[[?rfc6749]]]
 against a [=Secure Token Service=] endpoint. How the [=participant agent=] obtains the [=STS=] endpoint address is
 implementation-specific and beyond the scope of this specification.
 
 If an `token` is required to be included in the Self Issued ID token, the [=participant agent=] will need to request
 scopes for the access token. This is dependent on the API used to obtain the Self-Issued ID Token. An [=STS=]
-implementation may use endpoint parameters as defined in the [[[?rfc6749]]] to convey metadata necessary for the
-creation of the `token` claim. In this case, the Self-Issued ID Token request may contain a `bearer_access_scope`
+implementation MAY use endpoint parameters as defined in the [[[?rfc6749]]] to convey metadata necessary for the
+creation of the `token` claim. In this case, the Self-Issued ID Token request MAY contain a `bearer_access_scope`
 authorization request parameter set to a list of space-delimited scopes the `token` claim will be enabled for. If no
-`bearer_access_scope` parameter is present, the `token` claim should not be included.
+`bearer_access_scope` parameter is present, the `token` claim SHOULD NOT be included.
 
 <aside class="note">
 A non-normative OpenAPI spec of an [=STS=] implementing client credentials flow is provided [here](specifications/identity-trust-sts-api.yaml)
@@ -111,4 +111,4 @@ definitions, concatenated to a `vMAJOR.MINOR` number. The current specifications
 # The Base URL
 
 All endpoint URLs in this specification are relative. The base URL MUST use the HTTPS scheme. The base URL is
-implementation-specific and may include additional context information such as a sub-path that disambiguates a holder.
+implementation-specific and MAY include additional context information such as a sub-path that disambiguates a holder.

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -94,13 +94,13 @@ Self-Issued ID Token to provide the pre-authorization code to the issuer.
 
 ### Credential Request Message
 
-|              |                                                                                  |
-|--------------|----------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/issuance/credential-request-message-schema.json)       |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).      |
-|              | - `type`: A string specifying the `CredentialRequestMessage` type                |
-|              | - `holderPid`: A string corresponding to the request id on the Holder side type  |
-|              | - `credentials`: an array of strings, each referencing a [[[#credentialobject]]] |
+|              |                                                                                   |
+|--------------|-----------------------------------------------------------------------------------|
+| **Schema**   | [JSON Schema](./resources/issuance/credential-request-message-schema.json)        |
+| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).       |
+|              | - `type`: A string specifying the `CredentialRequestMessage` type.                |
+|              | - `holderPid`: A string corresponding to the request id on the Holder side.       |
+|              | - `credentials`: an array of strings, each referencing a [[[#credentialobject]]]. |
 
 The following is a non-normative example of a `CredentialRequestMessage`:
 
@@ -141,16 +141,16 @@ exact error code is implementation-specific.
 
 ### Credential Message
 
-|              |                                                                                                                      |
-|--------------|----------------------------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/issuance/credential-message-schema.json)                                                   |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                                           |
-|              | - `type`: A string specifying the `Credential Message` type.                                                         |
-|              | - `issuerPid`: A string corresponding to the issuance id on the Issuer side.                                         |
-|              | - `holderPid`: A string corresponding to the issuance id on the Holder side.                                         |
-|              | - `status`: A string stating whether the request was successful (`ISSUED`) or rejected (`REJECTED`)                  |
-|              | - `credentials`: An array of [Credential Container](#credential-container) Json objects as defined in the following. |
-|              | - `rejectionReason`: a String containing additional information why a request was rejected. Can be `null`.           |
+|              |                                                                                                                                  |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------|
+| **Schema**   | [JSON Schema](./resources/issuance/credential-message-schema.json)                                                               |
+| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                                      |
+|              | - `type`: A string specifying the `CredentialMessage` type.                                                                      |
+|              | - `issuerPid`: A string corresponding to the issuance id on the Issuer side.                                                     |
+|              | - `holderPid`: A string corresponding to the issuance id on the Holder side.                                                     |
+|              | - `status`: A string stating whether the request was successful (`ISSUED`) or rejected (`REJECTED`)                              |
+| **Optional** | - `credentials`: An array of [Credential Container](#credential-container) Json objects, as defined in the following subsection. |
+|              | - `rejectionReason`: a String containing additional information why a request was rejected.                                      |
 
 The following is a non-normative example of a [Credential Message](#credential-message) JSON body:
 
@@ -167,7 +167,7 @@ The following example shows a rejected credential request JSON body:
 
 Note that the `status` applies to the entire request, i.e. a request is considered _rejected_ if at least one credential
 could not be issued.
-Allowed values for the `status` are `"ISSUED"` and `"REJECTED"`. The `rejectionReason` field is optional and should not
+Allowed values for the `status` are `"ISSUED"` and `"REJECTED"`. The `rejectionReason` should not
 disclose any confidential information.
 
 ### Credential Container
@@ -181,7 +181,7 @@ The  [Credential Container](#credential-container) object contains the following
 | **Schema**   | [JSON Schema](./resources/issuance/credential-message-schema.json)                                                                                                                                                         |
 | **Required** | - `credentialType`: A single string specifying type of credential. See [VC DataModel 1.1](https://www.w3.org/TR/vc-data-model/#types) or [VC DataModel 2.0](https://www.w3.org/TR/vc-data-model-2.0/#types), respectively. |
 |              | - `payload`: A Json Literal ([[json-ld11]], sect. 4.2.2) containing a [=Verifiable Credential=] defined by ([[vc-data-model]]).                                                                                            |
-|              | - `format`:  a JSON string that describes the format of the credential to be issued                                                                                                                                        |
+|              | - `format`:  a JSON string that describes the format of the issued credential.                                                                                                                                             |
 
 ## Credential Offer API
 

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -12,11 +12,11 @@ issue a [=Verifiable Credential=]:
 ![Issuance Flow](specifications/issuance.flow.svg "Issuance Flow")
 
 1. The client sends a request to its [=Secure Token Service=] for a token including an access token. This could be a
-   [=Self-Issued ID Token=]. The API used to make this request is implementation specific. The client may include a set
+   [=Self-Issued ID Token=]. The API used to make this request is implementation specific. The client MAY include a set
    of scopes that define the [=Verifiable Credentials=] the client wants the [=Issuer Service=] to provide. This set of
-   scopes is determined out of band and may be derived from metadata the [=Credential Issuer=] has previously made
+   scopes is determined out of band and MAY be derived from metadata the [=Credential Issuer=] has previously made
    available to the client.
-2. The [=Secure Token Service=] responds with an access token, which may be included in the `token` claim of the
+2. The [=Secure Token Service=] responds with an access token, which MAY be included in the `token` claim of the
    [=Self-Issued ID Token=]. The access token can be used by the [=Issuer Service=] to write requested 
    [=Verifiable Credentials=] to the client's [=Credential Service=].
 3. The client makes a request to the [=Issuer Service=] for one or more [=Verifiable Credentials=] and includes
@@ -167,7 +167,7 @@ The following example shows a rejected credential request JSON body:
 
 Note that the `status` applies to the entire request, i.e. a request is considered _rejected_ if at least one credential
 could not be issued.
-Allowed values for the `status` are `"ISSUED"` and `"REJECTED"`. The `rejectionReason` should not
+Allowed values for the `status` are `"ISSUED"` and `"REJECTED"`. The `rejectionReason` SHOULD NOT
 disclose any confidential information.
 
 ### Credential Container
@@ -185,9 +185,9 @@ The  [Credential Container](#credential-container) object contains the following
 
 ## Credential Offer API
 
-Some scenarios involve the [=Credential Issuer=] making an initial offer. For example, an out-of-band process may result
+Some scenarios involve the [=Credential Issuer=] making an initial offer. For example, an out-of-band process MAY result
 in
-a credential offer. Or, a [=Credential Issuer=] may start a key rotation process which requires
+a credential offer. Or, a [=Credential Issuer=] MAY start a key rotation process which requires
 a [=Verifiable Credential=] to be
 reissued. In this case, the [=Credential Issuer=] can proactively prompt a [=Holder=] to request a
 new [=Verifiable Credential=]
@@ -206,13 +206,13 @@ a [=Verifiable Credential=] offer.
 
 ### Credential Offer Message
 
-|              |                                                                                                                    |
-|--------------|--------------------------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/issuance/credential-offer-message-schema.json)                                           |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                                         |
-|              | - `type`: A string specifying the `CredentialOfferMessage` type                                                    |
-|              | - `issuer`:  The [=Credential Issuer=] DID                                                                         |
-|              | - `credentials`: A JSON array, where every entry is a JSON object of type [[[#credentialobject]]] or a JSON string |
+|              |                                                                                                                     |
+|--------------|---------------------------------------------------------------------------------------------------------------------|
+| **Schema**   | [JSON Schema](./resources/issuance/credential-offer-message-schema.json)                                            |
+| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                         |
+|              | - `type`: A string specifying the `CredentialOfferMessage` type.                                                    |
+|              | - `issuer`:  The [=Credential Issuer=] DID.                                                                         |
+|              | - `credentials`: A JSON array, where every entry is a JSON object of type [[[#credentialobject]]] or a JSON string. |
 
 If the `credentials` property entries are type string, the value MUST be one of the `id` values of an object in the
 `credentialsSupported` returned from the [[[#issuer-metadata-api]]]. When processing, the [=Credential Service=]
@@ -235,15 +235,15 @@ The following is a non-normative example of a credential offer request:
 |              |                                                                                                                                                                                                                               |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./resources/issuance/credential-object-schema.json)                                                                                                                                                             |
-| **Required** | - `type`: A string specifying the `CredentialObject` type                                                                                                                                                                     |
-|              | - `credentialType`: A single string specifying type of credential being offered                                                                                                                                               |
-|              | - `id`: a string defining a unique, stable identifier for this `CredentialObject`                                                                                                                                             |
+| **Required** | - `type`: A string specifying the `CredentialObject` type.                                                                                                                                                                    |
+|              | - `credentialType`: A single string specifying type of credential being offered.                                                                                                                                              |
+|              | - `id`: a string defining a unique, stable identifier for this `CredentialObject`.                                                                                                                                            |
 | **Optional** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). As the `credentialObject` is usually embedded, its context is provided by the enveloping object.                                                  |
-|              | - `bindingMethods`: An array of strings defining the key material that an issued credential is bound to                                                                                                                       |
+|              | - `bindingMethods`: An array of strings defining the key material that an issued credential is bound to.                                                                                                                      |
 |              | - `credentialSchema`: A URL pointing to the credential schema of the object in a VC's `credentialSubject` property.                                                                                                           |
-|              | - `profile`: An string containing the alias of the [profiles](#profiles-of-the-decentralized-claims-protocol), e.g. `"vc20-bssl/jwt"`                                                                                         |
+|              | - `profile`: An string containing the alias of the [profiles](#profiles-of-the-decentralized-claims-protocol), e.g. `"vc20-bssl/jwt"`.                                                                                        |
 |              | - `issuancePolicy`: A [presentation definition](https://identity.foundation/presentation-exchange/spec/v2.1.1/#presentation-definition) [[presentation-ex]] signifying the required [=Verifiable Presentation=] for issuance. |
-|              | - `offerReason`: A reason for the offer as a string. Valid values may include `reissue` and `proof-key-revocation`                                                                                                            |
+|              | - `offerReason`: A reason for the offer as a string. Valid values MAY include `reissue` and `proof-key-revocation`.                                                                                                           |
 
 The following is a non-normative example of a `CredentialObject`:
 
@@ -270,9 +270,9 @@ supported by the [=Credential Issuer=].
 |--------------|-----------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./resources/issuance/issuer-metadata-schema.json)             |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). |
-|              | - `type`: A string specifying the `IssuerMetadata` type                     |
-|              | - `issuer`: A string containing the [=Credential Issuer=] DID               |
-| **Optional** | - `credentialsSupported`: A JSON array of [[[#credentialobject]]] elements  |
+|              | - `type`: A string specifying the `IssuerMetadata` type.                    |
+|              | - `issuer`: A string containing the [=Credential Issuer=] DID.              |
+| **Optional** | - `credentialsSupported`: A JSON array of [[[#credentialobject]]] elements. |
 
 The following is a non-normative example of a `IssuerMetadata` response object:
 
@@ -293,20 +293,20 @@ The Credential Request Status API defines the REQUIRED [=Issuer Service=] endpoi
 | **URL Path**    | `/requests/<request id>`  where the request id corresponds to the ID identified by the location header returned for a [[[#credential-request-message]]] |
 | **Response**    | [[[#credentialstatus]]] `HTTP 200`                                                                                                                      |     
 
-The [=Issuer Service=] MUST implement access control such that only the client that made the request may access a
+The [=Issuer Service=] MUST implement access control such that only the client that made the request MAY access a
 particular request status. A [=Self-Issued ID Token=] MUST be submitted in the HTTP `Authorization` header prefixed
 with `Bearer` of the request.
 
 ### CredentialStatus
 
-|              |                                                                             |
-|--------------|-----------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/issuance/credential-status-schema.json)           |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). |
-|              | - `type`: A string specifying the `CredentialStatus` type                   |
-|              | - `issuerPid`: A string corresponding to the issuance id on the Issuer side |
-|              | - `holderPid`: A string corresponding to the issuance id on the Holder side |
-|              | - `status`: A string with a value of `RECEIVED`, `REJECTED`, or `ISSUED`    |
+|              |                                                                              |
+|--------------|------------------------------------------------------------------------------|
+| **Schema**   | [JSON Schema](./resources/issuance/credential-status-schema.json)            |
+| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).  |
+|              | - `type`: A string specifying the `CredentialStatus` type.                   |
+|              | - `issuerPid`: A string corresponding to the issuance id on the Issuer side. |
+|              | - `holderPid`: A string corresponding to the issuance id on the Holder side. |
+|              | - `status`: A string with a value of `RECEIVED`, `REJECTED`, or `ISSUED`.    |
 
 The following is a non-normative example of a `CredentialStatus` response object:
 
@@ -322,17 +322,17 @@ create [=Verifiable Credential=] proofs.
 
 ### Key rotation
 
-Key rotation may be supported in the following way:
+Key rotation MAY be supported in the following way:
 
 1. After a defined `cryptoperiod`, a rotation is initiated, a new key pair is generated and the public key is added
    to a `verificationMethod` in the [=Credential Issuer=] DID document. The new private key is used to sign newly
    issued [=Verifiable Credential=] proofs.
 2. The old private key is decommissioned (archived or destroyed). However, the `verificationMethod` in
-   the [=Credential Issuer=] DID document are retained so existing issued [=Verifiable Credentials=] may be verified.
-3. At some point before existing [=Verifiable Credentials=] are set to expire, an [=Credential Issuer=] may make
+   the [=Credential Issuer=] DID document are retained so existing issued [=Verifiable Credentials=] MAY be verified.
+3. At some point before existing [=Verifiable Credentials=] are set to expire, an [=Credential Issuer=] MAY make
    credential offers for new [=Verifiable Credentials=] to [=Holders=] with the `offerReason = reissue` property.
 4. After a defined period, the rotated key's `verificationMethod` will be removed from the [=Credential Issuer=] DID
-   document. This period must at least extend to the expiration date of the last issued credential. At this point, any
+   document. This period MUST at least extend to the expiration date of the last issued credential. At this point, any
    existing [=Verifiable Credentials=] with proofs signed by the old (now rotated) key will become invalid.
 
 Implementors following this sequence SHOULD set the `expirationDate`/`validUntil` property of
@@ -341,14 +341,14 @@ SHOULD not be decommissioned until all credentials, that were signed with it, ha
 
 ### Key revocation
 
-Key revocation may be supported in the following way:
+Key revocation MAY be supported in the following way:
 
 1. After revocation is initiated, a new key pair is generated and the public key is added to a `verificationMethod` in
    the [=Credential Issuer=] DID document. The new private key is used to sign newly issued [=Verifiable Credential=]
    proofs.
 2. The old private key is decommissioned (archived or destroyed) and the `verificationMethod` in
    the [=Credential Issuer=] DID document is removed.
-3. The [=Credential Issuer=] may make credential offers for new [=Verifiable Credentials=] to [=Holders=] with the
+3. The [=Credential Issuer=] MAY make credential offers for new [=Verifiable Credentials=] to [=Holders=] with the
    `offerReason = proof-key-revocation` property.
 
 Upon revocation of a key pair, all credentials that were issued and proofed with that key, immediately become invalid.

--- a/specifications/dataspace.ecosystem.md
+++ b/specifications/dataspace.ecosystem.md
@@ -6,7 +6,7 @@ adheres to the model defined by the Dataspace Protocol [[dsp-base]]:
 - A <dfn>Dataspace</dfn> is a policy-based data sharing context between two or more entities.
 - The <dfn>Dataspace Governance Authority</dfn> is responsible for operational management of a [=dataspace=],
   including [=participant=] registration and designation of trust credential issuers.
-- A <dfn>Participant</dfn> is a member of the [=dataspace=]. Members may take on different roles, which are attested to
+- A <dfn>Participant</dfn> is a member of the [=dataspace=]. Members MAY take on different roles, which are attested to
   by verifiable credentials.
 - A <dfn>Participant Agent</dfn> performs tasks such as publishing a catalog or engaging in data transfer. Note that a
   participant agent is a logical construct and does not necessarily correspond to a single runtime process.
@@ -33,9 +33,9 @@ The registration system is run by the [=Dataspace Governance Authority=] and is 
 
 ### Participant Agent Systems
 
-[=Participants=] will run one or more agent systems that interact in the dataspace. These systems may offer data
-catalogs, perform data transfers, or provide application functionality. A [=participant=] may run the following
-identity-related agents. Note that this is a logical description and may not represent an actual deployment topology.
+[=Participants=] will run one or more agent systems that interact in the dataspace. These systems MAY offer data
+catalogs, perform data transfers, or provide application functionality. A [=participant=] MAY run the following
+identity-related agents. Note that this is a logical description and MAY not represent an actual deployment topology.
 
 <dfn data-lt="sts | Secure Token Service">Security Token Service (STS).</dfn>
 
@@ -56,7 +56,7 @@ The DIDS creates, signs and publishes DID documents.
 <dfn data-lt="is | Issuer Service">Issuer Service (IS)</dfn>
 
 The Issuer Service is run by trust anchor and manages the lifecycle of [=Verifiable Credentials=] in a dataspace. A
-dataspace may contain multiple Issuer Services run by different trust anchors. The Issuer Service:
+dataspace MAY contain multiple Issuer Services run by different trust anchors. The Issuer Service:
 
 - Issues  [=Verifiable Credentials=] for dataspace [=participants=].
 - Manages revocation lists for  [=Verifiable Credentials=] types it issues based

--- a/specifications/dcp.profiles.md
+++ b/specifications/dcp.profiles.md
@@ -20,7 +20,7 @@ model [conflicts](https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatu
 ### Homogeneity requirement
 
 Verifiable Credentials MUST be _homogenous_. This means the
-same data model version and proof mechanism must be used for both credentials and presentations. For example, a
+same data model version and proof mechanism MUST be used for both credentials and presentations. For example, a
 verifiable credential secured with an _enveloped proof_ using
 JOSE ([VC Data Model 2.0](https://www.w3.org/TR/vc-jose-cose/#with-jose)) is enclosed in a verifiable presentation 
 that is also secured with JWT/JOSE.
@@ -32,7 +32,7 @@ contains credentials of the same data model and proof mechanism.
 
 This non-normative section is intended to provide guidance to authors who aim at defining their own profile definition.
 
-For a usable profile, at least the following aspects must be defined:
+For a usable profile, at least the following aspects MUST be defined:
 
 - Verifiable Credential Data Model
 - Revocation System: specifies how the validity and expiration of Verifiable Credentials is checked

--- a/specifications/identity-trust-sts-api.yaml
+++ b/specifications/identity-trust-sts-api.yaml
@@ -37,7 +37,7 @@ paths:
                   description: Secret of the client requesting an SI token
                 grant_type:
                   type: string
-                  description: "Type of grant: must be set to client_credentials"
+                  description: "Type of grant: MUST be set to client_credentials"
               required:
               - audience
               - client_id

--- a/specifications/trust.model.md
+++ b/specifications/trust.model.md
@@ -19,7 +19,7 @@ The Issuer-Holder-Verifier model is mapped to the following architecture in this
 
 - Identity and claims information is exchanged between a [=Holder=] and a [=Verifier=] in the context of Dataspace
   Protocol message interactions [[dsp-base]]. These messages will contain metadata such as Offers and Agreements that
-  determine the [=Verifiable Credentials=] a [=Holder=] must present to a [=Verifier=].
+  determine the [=Verifiable Credentials=] a [=Holder=] MUST present to a [=Verifier=].
 - The [=Issuer Service=] issues credentials to a [=Holder=]'s [=Credential Service=] using the protocol defined in
   Section [[[#credential-issuance-protocol]]]. As part of this process, the [=Issuer Service=] will verify
   the [=Holder=]'s identifier using the [=Verifiable Data Registry=]. Since [=DID=]s are mandatory in this
@@ -28,7 +28,7 @@ The Issuer-Holder-Verifier model is mapped to the following architecture in this
   The [=Participant Agent=] engages in dataspace communications with the [=Verifier=] agent [[dsp-base]]. As part of
   these interactions, the [=Participant Agent=] will include a Self-Issued ID Token as defined in
   Section [[[#self-issued-id-tokens]]]. This token will be obtained from the [=STS=] controlled by the [=Holder=].
-  **Note that the [=STS=] is an internal system and therefore out of scope for the current specification. It may be a
+  **Note that the [=STS=] is an internal system and therefore out of scope for the current specification. It MAY be a
   standalone service or part of the [=Participant Agent=] or [=Credential Service=].** The Self-Issued ID Token will
   contain an access token bound to the [=Verifier=] that will be used to request a [=Verifiable Presentation=].
   The [=Holder=]'s [=Credential Service=] will verify the access token with the [=STS=].
@@ -77,7 +77,7 @@ key aspects of those trust relationships.
 
 All entities expect:
 
-- The [=Verifiable Data Registry=] to be tamper-evident and correctly reflect data controlled by all entities. This may
+- The [=Verifiable Data Registry=] to be tamper-evident and correctly reflect data controlled by all entities. This MAY
   be done through the use of cryptographic resources.
 - All [=Verifiable Credentials=] and [=Verifiable Presentations=] to be tamper-proof and support revocation.
 - Dataspace Protocol interactions and those defined in this specification to be secure and use Transport Level
@@ -95,9 +95,9 @@ The [=Issuer=] expects:
 The [=Holder=] expects:
 
 - The [=Dataspace Governance Authority=] to provide a secure list of trusted [=Issuer=] [=DID=]s. How this list is provided is out
-  of scope of the current specification but may be part of the [=Verifiable Data Registry=].
+  of scope of the current specification but MAY be part of the [=Verifiable Data Registry=].
 - The [=Dataspace Governance Authority=] to provide a secure list of participant [=DIDs=]. How this list is provided is out
-  of scope of the current specification but may be part of the [=Verifiable Data Registry=].
+  of scope of the current specification but MAY be part of the [=Verifiable Data Registry=].
 - The [=Credential Service=] to maintain integrity and not release data to unauthorized parties.
 - The [=Issuer=] to issue credentials correctly, including binding them to the holder in a tamper-proof way, and
   maintaining credential integrity.
@@ -108,7 +108,7 @@ The [=Holder=] expects:
 The [=Verifier=] expects:
 
 - The [=Dataspace Governance Authority=] to provide a secure list of trusted [=Issuer=] [=DID=]s. How this list is provided is out
-  of scope of the current specification but may be part of the [=Verifiable Data Registry=]. [=Verifiers=] can
+  of scope of the current specification but MAY be part of the [=Verifiable Data Registry=]. [=Verifiers=] can
   recognize several [=Dataspace Governance Authorities=].
 
 - The [=Issuer=] to issue credentials correctly, including binding them to the holder in a tamper-proof way, and

--- a/specifications/verifiable.presentation.protocol.md
+++ b/specifications/verifiable.presentation.protocol.md
@@ -22,11 +22,11 @@ The following sequence diagram depicts a non-normative flow where a client inter
 ![Presentation Flow](specifications/auth.flow.svg "Presentation Flow")
 
 1. The client sends a request to its [=Secure Token Service=] for a token including an access token. This could be a
-   [=Self-Issued ID Token=]. The API used to make this request is implementation specific. The client may include a set
+   [=Self-Issued ID Token=]. The API used to make this request is implementation specific. The client MAY include a set
    of scopes that define the [=Verifiable Credentials=] the client wants the [=Verifier=] to have access to. This set of
-   scopes is determined out of band and may be derived from metadata the [=verifier=] has previously made available to
+   scopes is determined out of band and MAY be derived from metadata the [=verifier=] has previously made available to
    the client.
-2. The [=Secure Token Service=] responds with an access token, which may be included in the `token` claim of the
+2. The [=Secure Token Service=] responds with an access token, which MAY be included in the `token` claim of the
    [=Self-Issued ID Token=]. The access token can be used by the verifier to request [=Verifiable Credentials=] from the
    client's [=Credential Service=].
 3. The client makes a request to the [=Verifier=] for a protected resource and includes a [=Self-Issued ID Token=]
@@ -67,9 +67,9 @@ the [=Credential Service=]. The following is a non-normative example of a `Crede
 
 ## Credential Service Security
 
-As described in the previous presentation flow, a [=Credential Service=] may require an access token when processing a
+As described in the previous presentation flow, a [=Credential Service=] MAY require an access token when processing a
 request from a [=Verifier=]. The format of the access token is not defined. How access control is defined in
-a [=Credential Service=] is implementation-specific. For example, implementations may provide the ability to selectively
+a [=Credential Service=] is implementation-specific. For example, implementations MAY provide the ability to selectively
 restrict access to resources.
 
 ### Submitting an Access Token
@@ -100,7 +100,7 @@ exact error code is implementation-specific.
 |              |                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./resources/presentation/presentation-query-message-schema.json)                  |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                      |
+| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                     |
 |              | - `type`: A string specifying the `PresentationQueryMessage` type.                              |
 | **Optional** | - `scope`: An array of scopes corresponding to Section [[[#scopes]]].                           |
 |              | - `presentationDefinition`: A valid `Presentation Definition` according to [[presentation-ex]]. |
@@ -148,16 +148,16 @@ example:
 
 `org.eclipse.dspace.dcp.vc.type:Member`
 
-denotes read-only access to the VC type `Member` and may be used to request a VC or VP.
+denotes read-only access to the VC type `Member` and MAY be used to request a VC or VP.
 
 ##### The `org.eclipse.dspace.dcp.vc.id` Alias
 
-The `org.eclipse.dspace.dcp.vc.id` alias value must be supported and is used to specify access to a verifiable
+The `org.eclipse.dspace.dcp.vc.id` alias value MUST be supported and is used to specify access to a verifiable
 credential by id. For example:
 
 `org.eclipse.dspace.dcp.vc.id:8247b87d-8d72-47e1-8128-9ce47e3d829d`
 
-denotes read-only access to the VC identified by `8247b87d-8d72-47e1-8128-9ce47e3d829d` and may be used to request a
+denotes read-only access to the VC identified by `8247b87d-8d72-47e1-8128-9ce47e3d829d` and MAY be used to request a
 [=Verifiable Credential=].
 
 ### Presentation Response Message
@@ -167,7 +167,7 @@ denotes read-only access to the VC identified by `8247b87d-8d72-47e1-8128-9ce47e
 | **Schema**   | [JSON Schema](./resources/presentation/presentation-response-message-schema.json)                                                                                                 |
 | **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                                                                                       |
 |              | - `type`: A string specifying the `PresentationResponseMessage` type.                                                                                                             |
-|              | - `presentation`: An array of [=Verifiable Presentations=]. The [=Verifiable Presentations=] may be strings, JSON objects, or a combination of both depending on the format.</br> |
+|              | - `presentation`: An array of [=Verifiable Presentations=]. The [=Verifiable Presentations=] MAY be strings, JSON objects, or a combination of both depending on the format.</br> |
 | **Optional** | - `presentationSubmission`: A valid `Presentation Submission` according to [[presentation-ex]].                                                                                   |
 
 A `PresentationResponseMessage` SHOULD only include valid (non-expired, non-revoked, non-suspended) credentials.


### PR DESCRIPTION
## WHAT

Corrects typos on the issuance protocol section and suggests superficial changes on the Issuance Protocol tables.

Closes #220

## How was the issue fixed?

As explained in #220.

## More context

Usage of uppercase in line with RFC 2119 and addition of punctuation on tables.