### PR TITLE
feat: rephrase terminology section and update references to VC DataModel 2.0

### DIFF
--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -62,7 +62,7 @@ following is a non-normative example of a `Issuer Service` entry:
 
 All endpoint addresses are defined relative to the base URL of the [=Issuer Service=]. The [=Credential Issuer=] will
 use the base URL for the `issuer` field in all [=Verifiable Credentials=] it issues as defined by the `issuer`
-property ([[vc-data-model]]).
+property ([[vc-data-model-2.0]]).
 
 No assumptions are made about the base URL, for example, if it is a domain, subdomain, or contains a path.
 

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -62,7 +62,7 @@ following is a non-normative example of a `Issuer Service` entry:
 
 All endpoint addresses are defined relative to the base URL of the [=Issuer Service=]. The [=Credential Issuer=] will
 use the base URL for the `issuer` field in all [=Verifiable Credentials=] it issues as defined by the `issuer`
-property ([[vc-data-model-2.0]]).
+property of the [VC DataModel version of the selected profile](#profiles-of-the-decentralized-claims-protocol).
 
 No assumptions are made about the base URL, for example, if it is a domain, subdomain, or contains a path.
 
@@ -180,7 +180,7 @@ The  [Credential Container](#credential-container) object contains the following
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./resources/issuance/credential-message-schema.json)                                                                                                                                                         |
 | **Required** | - `credentialType`: A single string specifying type of credential. See [VC DataModel 1.1](https://www.w3.org/TR/vc-data-model/#types) or [VC DataModel 2.0](https://www.w3.org/TR/vc-data-model-2.0/#types), respectively. |
-|              | - `payload`: A Json Literal ([[json-ld11]], sect. 4.2.2) containing a [=Verifiable Credential=] defined by ([[vc-data-model]]).                                                                                            |
+|              | - `payload`: A Json Literal ([[json-ld11]], sect. 4.2.2) containing a [=Verifiable Credential=] defined by [VC DataModel version of the selected profile](#profiles-of-the-decentralized-claims-protocol).                                                                                            |
 |              | - `format`:  a JSON string that describes the format of the credential to be issued                                                                                                                                        |
 
 ## Credential Offer API

--- a/specifications/terminology.md
+++ b/specifications/terminology.md
@@ -4,19 +4,19 @@ The following terms are used to describe concepts in this specification.
 
 - <dfn data-lt="Claim | Claims">Claim</dfn> - An assertion made about a [=Subject=].
 - <dfn>DID</dfn> - A decentralized identifier as defined by [[[did-core]]].
-- <dfn>Holder</dfn> - An entity that possesses a set of identity resources as defined by [[[vc-data-model]]].
+- <dfn>Holder</dfn> - An entity that possesses a set of identity resources as defined by the specific VC DataModel that is mandated by the profile [[[vc-data-model-2.0]]].
   The holder will typically be the subject of a [=Verifiable Credential=].
 - <dfn>Issuer</dfn> - An entity that asserts [=claims=] about one or more subjects by issuing
   a [=Verifiable Credential=] to a [=Holder=].
 - <dfn>Resource</dfn> - A resource is an entity managed by the Credential Service such as a [=Verifiable Credential=]
   or [=Verifiable Presentation=].
 - <dfn>Subject</dfn> - The target of a set of claims contained in a [=Verifiable Credential=] as defined
-  by [[[vc-data-model]]]. In a dataspace, a subject will be a participant.
+  by [[[vc-data-model-2.0]]]. In a dataspace, a subject will be a participant.
 - <dfn data-lt="Verifiable Credential | Verifiable Credentials">Verifiable Credential</dfn> A tamper-evident credential
-  whose authorship can be cryptographically verified as defined by [[[vc-data-model]]].
+  whose authorship can be cryptographically verified as defined by the specific VC DataModel that is mandated by the profile [[[vc-data-model-2.0]]].
 - <dfn data-lt="Verifiable Presentation | Verifiable Presentations">Verifiable Presentation</dfn> A tamper-evident
-  presentation of information whose authorship can be cryptographically verified as defined by [[[vc-data-model]]].
+  presentation of information whose authorship can be cryptographically verified as defined by the specific VC DataModel that is mandated by the profile [[[vc-data-model-2.0]]].
 - <dfn>Verifiable Data Registry</dfn> - Maintains identifiers such as [=DIDs=] and [=Verifiable Credential=] schemas in
   a dataspace.
 - <dfn>Verifier</dfn> - An entity that receives a [=Verifiable Credential=], optionally presented inside
-  a [=Verifiable Presentation=] as defined by [[[vc-data-model]]].
+  a [=Verifiable Presentation=] as defined by [[[vc-data-model-2.0]]].

--- a/specifications/terminology.md
+++ b/specifications/terminology.md
@@ -4,19 +4,19 @@ The following terms are used to describe concepts in this specification.
 
 - <dfn data-lt="Claim | Claims">Claim</dfn> - An assertion made about a [=Subject=].
 - <dfn>DID</dfn> - A decentralized identifier as defined by [[[did-core]]].
-- <dfn>Holder</dfn> - An entity that possesses a set of identity resources as defined by the specific VC DataModel that is mandated by the profile [[[vc-data-model-2.0]]].
+- <dfn>Holder</dfn> - An entity that possesses a set of identity resources as defined by the [VC DataModel version of the selected profile](#profiles-of-the-decentralized-claims-protocol).
   The holder will typically be the subject of a [=Verifiable Credential=].
 - <dfn>Issuer</dfn> - An entity that asserts [=claims=] about one or more subjects by issuing
   a [=Verifiable Credential=] to a [=Holder=].
 - <dfn>Resource</dfn> - A resource is an entity managed by the Credential Service such as a [=Verifiable Credential=]
   or [=Verifiable Presentation=].
 - <dfn>Subject</dfn> - The target of a set of claims contained in a [=Verifiable Credential=] as defined
-  by [[[vc-data-model-2.0]]]. In a dataspace, a subject will be a participant.
+  by the [VC DataModel version of the selected profile](#profiles-of-the-decentralized-claims-protocol). In a dataspace, a subject will be a participant.
 - <dfn data-lt="Verifiable Credential | Verifiable Credentials">Verifiable Credential</dfn> A tamper-evident credential
-  whose authorship can be cryptographically verified as defined by the specific VC DataModel that is mandated by the profile [[[vc-data-model-2.0]]].
+  whose authorship can be cryptographically verified as defined by the [VC DataModel version of the selected profile](#profiles-of-the-decentralized-claims-protocol).
 - <dfn data-lt="Verifiable Presentation | Verifiable Presentations">Verifiable Presentation</dfn> A tamper-evident
-  presentation of information whose authorship can be cryptographically verified as defined by the specific VC DataModel that is mandated by the profile [[[vc-data-model-2.0]]].
+  presentation of information whose authorship can be cryptographically verified as defined by [VC DataModel version of the selected profile](#profiles-of-the-decentralized-claims-protocol).
 - <dfn>Verifiable Data Registry</dfn> - Maintains identifiers such as [=DIDs=] and [=Verifiable Credential=] schemas in
   a dataspace.
 - <dfn>Verifier</dfn> - An entity that receives a [=Verifiable Credential=], optionally presented inside
-  a [=Verifiable Presentation=] as defined by [[[vc-data-model-2.0]]].
+  a [=Verifiable Presentation=] as defined by the [VC DataModel version of the selected profile](#profiles-of-the-decentralized-claims-protocol).

--- a/specifications/trust.model.md
+++ b/specifications/trust.model.md
@@ -1,6 +1,6 @@
 # Trust Model and Information Flow Architecture
 
-This specification is based on the Issuer-Holder-Verifier model as described in the [[[vc-data-model-2.0]]]:
+This specification is based on the Issuer-Holder-Verifier model as described in the [VC DataModel version of the selected profile](#profiles-of-the-decentralized-claims-protocol):
 
 ![alt text 2](specifications/issuer-holder-verifier-model.svg "The Issuer-Holder-Verifier Model")
 

--- a/specifications/trust.model.md
+++ b/specifications/trust.model.md
@@ -1,6 +1,6 @@
 # Trust Model and Information Flow Architecture
 
-This specification is based on the Issuer-Holder-Verifier model as described in the [[[vc-data-model]]]:
+This specification is based on the Issuer-Holder-Verifier model as described in the [[[vc-data-model-2.0]]]:
 
 ![alt text 2](specifications/issuer-holder-verifier-model.svg "The Issuer-Holder-Verifier Model")
 


### PR DESCRIPTION
## WHAT

- updated the terminology section in alignment with issue #222 
- update all references to the VC Datamodel version 2.0, which is not in draft status anymore

Closes #222

## How was the issue fixed?

The terminology reference to VC Datamodel was formulated a bit misleading (see #222 ). Additionally we should take the newest VC Data Model version as a reference for our specification, even though we allow both through profiles. All terminology mentioned there also align with the current state of the specification pointing to VC Data Model v1.1.

## More context
https://www.w3.org/TR/vc-data-model-2.0/