### PR TITLE
feat: test examples against schemas before jsonld handling

### DIFF
--- a/artifacts/src/test/java/org/eclipse/dcp/context/issuance/IssuanceContextTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/context/issuance/IssuanceContextTest.java
@@ -35,6 +35,11 @@ public class IssuanceContextTest extends AbstractJsonLdTest {
     }
 
     @Test
+    void verifyCredentialMessageRejected() {
+        verifyRoundTrip("/issuance/example/credential-message-rejected.json", "/issuance/credential-message-schema.json");
+    }
+
+    @Test
     void verifyCredentialOfferMessage() {
         verifyRoundTrip("/issuance/example/credential-offer-message.json", "/issuance/credential-offer-message-schema.json");
     }

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/fixtures/AbstractSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/fixtures/AbstractSchemaTest.java
@@ -38,7 +38,6 @@ public abstract class AbstractSchemaTest {
     protected static final String ENUM = "enum";
     private static final String CLASSPATH_SCHEMA = "classpath:/";
     protected JsonSchema schema;
-    protected String example;
 
     protected void setUp(String schemaFile) {
         var schemaFactory = JsonSchemaFactory.getInstance(V202012, builder ->
@@ -48,13 +47,6 @@ public abstract class AbstractSchemaTest {
         );
 
         schema = schemaFactory.getSchema(SchemaLocation.of(DCP_PREFIX + schemaFile));
-
-
-        var lastSlash = schemaFile.lastIndexOf('/');
-        var basePath = schemaFile.substring(0, lastSlash);
-        var fileName = schemaFile.substring(lastSlash + 1);
-        var examplePath = basePath + "/example/" + fileName.replace("-schema", "");
-        example = loadExample(examplePath);
     }
 
 
@@ -69,14 +61,5 @@ public abstract class AbstractSchemaTest {
 
     public record SchemaError(String property, String type) {
 
-    }
-
-    protected String loadExample(String path) {
-        InputStream stream = getClass().getResourceAsStream(path);
-        try {
-            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/fixtures/AbstractSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/fixtures/AbstractSchemaTest.java
@@ -19,10 +19,6 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.ValidationMessage;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-
 import static com.networknt.schema.SpecVersion.VersionFlag.V202012;
 import static org.eclipse.dcp.schema.SchemaConstants.DCP_PREFIX;
 

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialOfferMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialOfferMessageSchemaTest.java
@@ -56,8 +56,6 @@ public class CredentialOfferMessageSchemaTest extends AbstractSchemaTest {
     void verifySchema() {
         assertThat(schema.validate(CREDENTIAL_OFFER_MESSAGE.formatted(CREDENTIAL_OBJECT), JSON)).isEmpty();
 
-        assertThat(schema.validate(example, JSON)).isEmpty();
-
         assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_CREDENTIAL_ISSUER.formatted(CREDENTIAL_OBJECT), JSON))
                 .extracting(this::errorExtractor)
                 .containsExactly(error("issuer", REQUIRED));


### PR DESCRIPTION
## WHAT

This PR partly rolls back changes made in #233 in favor of validating the examples against the json schemas before expansion and compaction. It also adds a previously unused example to test execution.

Closes #235
