### PR TITLE
fix: inconsistency in the CredentialObject definition

### DIFF
--- a/artifacts/src/main/resources/issuance/credential-object-schema.json
+++ b/artifacts/src/main/resources/issuance/credential-object-schema.json
@@ -45,11 +45,6 @@
       },
       "required": [
         "id",
-        "credentialType",
-        "offerReason",
-        "bindingMethods",
-        "profile",
-        "issuancePolicy",
         "type"
       ]
     }

--- a/artifacts/src/main/resources/issuance/example/issuer-metadata.json
+++ b/artifacts/src/main/resources/issuance/example/issuer-metadata.json
@@ -10,6 +10,7 @@
       "type": "CredentialObject",
       "credentialType": "CompanyCredential",
       "offerReason": "reissue",
+      "credentialSchema": "https://example.com/company-credential-schema.json",
       "bindingMethods": [
         "did:web"
       ],

--- a/artifacts/src/main/resources/issuance/issuer-metadata-schema.json
+++ b/artifacts/src/main/resources/issuance/issuer-metadata-schema.json
@@ -18,7 +18,21 @@
         "credentialsSupported": {
           "type": "array",
           "items": {
-            "$ref": "https://w3id.org/dspace-dcp/v1.0/issuance/credential-object-schema.json#/definitions/CredentialObject"
+            "allOf": [
+              {
+                "$ref": "https://w3id.org/dspace-dcp/v1.0/issuance/credential-object-schema.json#/definitions/CredentialObject"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "credentialType",
+                  "credentialSchema",
+                  "offerReason",
+                  "bindingMethods",
+                  "profile"
+                ]
+              }
+            ]
           }
         },
         "issuer": {

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialObjectSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/CredentialObjectSchemaTest.java
@@ -98,16 +98,18 @@ public class CredentialObjectSchemaTest extends AbstractSchemaTest {
     @Test
     void verifySchema() {
         assertThat(schema.validate(CREDENTIAL_OBJECT, JSON)).isEmpty();
+    }
+
+    @Test
+    void verifySchema_missingRequiredFields() {
         assertThat(schema.validate(INVALID_CREDENTIAL_OBJECT, JSON))
                 .extracting(this::errorExtractor)
                 .containsExactly(
-                        error("id", REQUIRED),
-                        error("credentialType", REQUIRED),
-                        error("offerReason", REQUIRED),
-                        error("bindingMethods", REQUIRED),
-                        error("profile", REQUIRED),
-                        error("issuancePolicy", REQUIRED));
+                        error("id", REQUIRED));
+    }
 
+    @Test
+    void verifySchema_missingTypeAndContext() {
         assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_TYPE_AND_CONTEXT, JSON))
                 .hasSize(1)
                 .extracting(this::errorExtractor)

--- a/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/IssuerMetadataSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dcp/schema/issuance/IssuerMetadataSchemaTest.java
@@ -31,13 +31,22 @@ public class IssuerMetadataSchemaTest extends AbstractSchemaTest {
                 "issuer": "did:web:issuer-url",
                 "credentialsSupported": [%s]
             }""";
-
+    public static final String CREDENTIAL_OBJECT_INCOMPLETE = """
+            {
+                "id": "d5c77b0e-7f4e-4fd5-8c5f-28b5fc3f96d1",
+                "type": "CredentialObject",
+                "credentialType": "VerifiableCredential",
+                "offerReason": "reissue",
+                "bindingMethods": [
+                  "did:web"
+                ]
+            }
+            """;
     private static final String INVALID_ISSUER_METADATA = """
             {
               "@context": ["https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"],
               "type": "IssuerMetadata"
             }""";
-
     private static final String INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_TYPE_AND_CONTEXT = """
             {
               "issuer": "did:web:issuer-url",
@@ -47,10 +56,25 @@ public class IssuerMetadataSchemaTest extends AbstractSchemaTest {
     @Test
     void verifySchema() {
         assertThat(schema.validate(ISSUER_METADATA.formatted(CREDENTIAL_OBJECT), JSON)).isEmpty();
+    }
+
+    @Test
+    void verifySchema_missingIssuerAndCredentialsSupported() {
         assertThat(schema.validate(INVALID_ISSUER_METADATA, JSON))
                 .extracting(this::errorExtractor)
                 .containsExactly(error("issuer", REQUIRED), error("credentialsSupported", REQUIRED));
 
+    }
+
+    @Test
+    void verifySchema_credentialSupportedIsIncomplete() {
+        assertThat(schema.validate(ISSUER_METADATA.formatted(CREDENTIAL_OBJECT_INCOMPLETE), JSON))
+                .extracting(this::errorExtractor)
+                .containsExactlyInAnyOrder(error("credentialSchema", REQUIRED), error("profile", REQUIRED));
+    }
+
+    @Test
+    void verifySchema_missingTypeAndContext() {
         assertThat(schema.validate(INVALID_CREDENTIAL_REQUEST_MESSAGE_NO_TYPE_AND_CONTEXT.formatted(CREDENTIAL_OBJECT), JSON))
                 .hasSize(2)
                 .extracting(this::errorExtractor)

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -208,17 +208,18 @@ a [=Verifiable Credential=] offer.
 
 ### Credential Offer Message
 
-|              |                                                                                                                     |
-|--------------|---------------------------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./resources/issuance/credential-offer-message-schema.json)                                            |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                         |
-|              | - `type`: A string specifying the `CredentialOfferMessage` type.                                                    |
-|              | - `issuer`:  The [=Credential Issuer=] DID.                                                                         |
-|              | - `credentials`: A JSON array, where every entry is a JSON object of type [[[#credentialobject]]] or a JSON string. |
+|              |                                                                                                              |
+|--------------|--------------------------------------------------------------------------------------------------------------|
+| **Schema**   | [JSON Schema](./resources/issuance/credential-offer-message-schema.json)                                     |
+| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                  |
+|              | - `type`: A string specifying the `CredentialOfferMessage` type.                                             |
+|              | - `issuer`:  The [=Credential Issuer=] DID.                                                                  |
+|              | - `credentials`: A non-empty JSON array, where every entry is a JSON object of type [[[#credentialobject]]]. |
 
-If the `credentials` property entries are type string, the value MUST be one of the `id` values of an object in the
-`credentialsSupported` returned from the [[[#issuer-metadata-api]]]. When processing, the [=Credential Service=]
-MUST resolve this string value to the respective object.
+If the entries in the `credentials` property are _sparse_, i.e., only contain an `id`, the values of all other properties
+of the [[[#credentialobject]]] must be taken from the `credentialsSupported` list returned from
+the [[[#issuer-metadata-api]]]. When processing, the [=Credential Service=] MUST resolve this string value to the
+respective object.
 
 The following is a non-normative example of a credential offer request:
 
@@ -233,9 +234,9 @@ The following is a non-normative example of a credential offer request:
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./resources/issuance/credential-object-schema.json)                                                                                                                                                             |
 | **Required** | - `type`: A string specifying the `CredentialObject` type.                                                                                                                                                                    |
-|              | - `credentialType`: A single string specifying type of credential being offered.                                                                                                                                              |
 |              | - `id`: a string defining a unique, stable identifier for this `CredentialObject`                                                                                                                                             |
 | **Optional** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). As the `credentialObject` is usually embedded, its context is provided by the enveloping object.                                                  |
+|              | - `credentialType`: A single string specifying type of credential being offered.                                                                                                                                              |
 |              | - `bindingMethods`: An array of strings defining the key material that an issued credential is bound to.                                                                                                                      |
 |              | - `credentialSchema`: A URL pointing to the credential schema of the object in a VC's `credentialSubject` property.                                                                                                           |
 |              | - `profile`: An string containing the alias of the [profiles](#profiles-of-the-decentralized-claims-protocol), e.g. `"vc20-bssl/jwt"`.                                                                                        |
@@ -277,6 +278,9 @@ The following is a non-normative example of a `IssuerMetadata` response object:
     <pre class="json" data-include="./resources/issuance/example/issuer-metadata.json">
     </pre>
 </aside>  
+
+Every `CredentialObject` in the `credentialsSupported` array MUST contain all optional properties defined
+in [[[#credentialobject]]].
 
 ## Credential Request Status API
 


### PR DESCRIPTION
## WHAT

makes the spec and the schema of the `CredentialObject` consistent

Closes #234

## How was the issue fixed?

there was an inconsistency

## More context

_List other areas that have changed but are not necessarily linked to the main feature. This could be naming changes,
bugs that were encountered and were fixed inline, etc._

