### PR TITLE
chore: publish v1

### DIFF
--- a/.github/scripts/index.html
+++ b/.github/scripts/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="refresh"
-          content="0;url=https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC4"/>
-    <link rel="canonical" href="https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC4"/>
+          content="0;url=https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/"/>
+    <link rel="canonical" href="https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/"/>
 </head>
 <body>
 <h4>
-    This redirects to the latest Release Candidate <a href="https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC4">here</a>
+    This redirects to the latest Release Candidate <a href="https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/">here</a>
 </h4>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,8 +5,7 @@
     <script src='https://www.w3.org/Tools/respec/respec-w3c' async class='remove'></script>
     <script class='remove'>
         var respecConfig = {
-            specStatus: "base",
-            publishDate: "2025-07-18",
+            specStatus: "unofficial",
             latestVersion: "https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/releases/tag/v1.0",
             editors: [{
                 name: "Jim Marino",
@@ -129,14 +128,14 @@
             },
         };
     </script>
-    <title>Eclipse Decentralized Claims Protocol v1.0</title>
+    <title>Eclipse Decentralized Claims Protocol NEXT</title>
 </head>
 <body>
 <p class="copyright">
     This document is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">The Apache License,
     Version 2.0</a>.
 </p>
-<h1 id="title">Eclipse Decentralized Claims Protocol </br>v1.0</h1>
+<h1 id="title">Eclipse Decentralized Claims Protocol </br>NEXT</h1>
 <section id='abstract'>
     <p>
         Dataspaces require the ability to communicate participant identities and credentials to secure data access. This
@@ -146,6 +145,10 @@
 </section>
 <section id='sotd' class="override">
     <h2>Status of This Document</h2>
+    <p>
+        With <a href="https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/">v1.0</a> released, further
+        releases of the DCP are currently not planned.
+    </p>
     <p>
         This version (v1.0) of the Dataspace Protocol specification is a release of the specification and considered to
         be stable. Further changes shall not affect conformity. All changes made to the specification can be reviewed in

--- a/index.html
+++ b/index.html
@@ -5,8 +5,9 @@
     <script src='https://www.w3.org/Tools/respec/respec-w3c' async class='remove'></script>
     <script class='remove'>
         var respecConfig = {
-            specStatus: "unofficial",
-            latestVersion: "https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/releases/tag/0.8.1",
+            specStatus: "base",
+            publishDate: "2025-07-18",
+            latestVersion: "https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/releases/tag/v1.0",
             editors: [{
                 name: "Jim Marino",
                 url: "https://github.com/jimmarino",
@@ -128,14 +129,14 @@
             },
         };
     </script>
-    <title>Eclipse Decentralized Claims Protocol v1.0-RC5</title>
+    <title>Eclipse Decentralized Claims Protocol v1.0</title>
 </head>
 <body>
 <p class="copyright">
     This document is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">The Apache License,
     Version 2.0</a>.
 </p>
-<h1 id="title">Eclipse Decentralized Claims Protocol </br>v1.0-RC5</h1>
+<h1 id="title">Eclipse Decentralized Claims Protocol </br>v1.0</h1>
 <section id='abstract'>
     <p>
         Dataspaces require the ability to communicate participant identities and credentials to secure data access. This
@@ -146,12 +147,11 @@
 <section id='sotd' class="override">
     <h2>Status of This Document</h2>
     <p>
-        This specification is a work-in-progress affiliated with the
-        <a href="https://dataspace.eclipse.org/">Eclipse Dataspace Working Group</a> that has not yet reached draft
-        status. If you have a question or would like to comment on an aspect of this specification, please open a
-        <a href="https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/discussions">discussion</a>.
-        If you have found an error, please file an <a
-            href="https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/issues">issue</a>.
+        This version (v1.0) of the Dataspace Protocol specification is a release of the specification and considered to
+        be stable. Further changes shall not affect conformity. All changes made to the specification can be reviewed in
+        the <a href="https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/">GitHub repository</a>.
+        This specification is affiliated with the
+        <a href="https://dataspace.eclipse.org/">Eclipse Dataspace Working Group</a>.
     </p>
 </section>
 


### PR DESCRIPTION
## WHAT

Publishes the stable v1.0 of the Decentralized Claims Protocol, executing on the [successful ballot and release review](https://gitlab.eclipse.org/eclipsefdn/emo-team/emo/-/issues/997).

## More context

As with every release, please adhere to WEBSITE.md. I'd like to see at least three concurring committer reviews on this PR.
**When merging, DO NOT SQUASH.**