### PR TITLE
fix: RFC 2119 keywords upper case

### DIFF
--- a/specifications/base.protocol.md
+++ b/specifications/base.protocol.md
@@ -42,28 +42,28 @@ The following claims MUST be included in the Self-Issued ID Token:
 
 A Self-Issued ID Token MAY contain an access token as a `token` claim that can be used by the [=Verifier=] to
 obtain [=Verifiable Presentations=] from the participant's [=Credential Service=]. The format of the `token` is
-implementation-specific and therefore should be treated as an opaque string by the [=Verifier=].
+implementation-specific and therefore SHOULD be treated as an opaque string by the [=Verifier=].
 
 ### Obtaining Self-Issued ID Tokens
 
 _This section is non-normative._
 
-How a Self-Issued ID token is obtained from a [=Secure Token Service=] is implementation-specific. An [=STS=] may
+How a Self-Issued ID token is obtained from a [=Secure Token Service=] is implementation-specific. An [=STS=] MAY
 support a
 variety of APIs, including OAuth 2.
 
 #### Using the OAuth 2 Client Credential Grant
 
-A Self-Issued ID Token may be obtained by executing a Client Credential Grant as defined in [[[?rfc6749]]]
+A Self-Issued ID Token MAY be obtained by executing a Client Credential Grant as defined in [[[?rfc6749]]]
 against a [=Secure Token Service=] endpoint. How the [=participant agent=] obtains the [=STS=] endpoint address is
 implementation-specific and beyond the scope of this specification.
 
-If an `token` is required to be included in the Self Issued ID token, the [=participant agent=] will need to request
+If an `token` is REQUIRED to be included in the Self Issued ID token, the [=participant agent=] will need to request
 scopes for the access token. This is dependent on the API used to obtain the Self-Issued ID Token. An [=STS=]
-implementation may use endpoint parameters as defined in the [[[?rfc6749]]] to convey metadata necessary for the
-creation of the `token` claim. In this case, the Self-Issued ID Token request may contain a `bearer_access_scope`
+implementation MAY use endpoint parameters as defined in the [[[?rfc6749]]] to convey metadata necessary for the
+creation of the `token` claim. In this case, the Self-Issued ID Token request MAY contain a `bearer_access_scope`
 authorization request parameter set to a list of space-delimited scopes the `token` claim will be enabled for. If no
-`bearer_access_scope` parameter is present, the `token` claim should not be included.
+`bearer_access_scope` parameter is present, the `token` claim SHOULD not be included.
 
 <aside class="note">
 A non-normative OpenAPI spec of an [=STS=] implementing client credentials flow is provided [here](specifications/identity-trust-sts-api.yaml)
@@ -105,10 +105,10 @@ contexts that facilitate this approach to interoperability.
 ## The Decentralized Claims Protocol Context
 
 The [[[json-ld11]]] context URI for the specification is: `https://w3id.org/dspace-dcp/v1.0/dcp.jsonld`. Future
-specification releases shall reuse the versioning schema according to the [Semantic Versioning](https://semver.org/) 
+specification releases SHALL reuse the versioning schema according to the [Semantic Versioning](https://semver.org/) 
 definitions, concatenated to a `vMAJOR.MINOR` number. The current specifications use `1.0` version.
 
 # The Base URL
 
 All endpoint URLs in this specification are relative. The base URL MUST use the HTTPS scheme. The base URL is
-implementation-specific and may include additional context information such as a sub-path that disambiguates a holder.
+implementation-specific and MAY include additional context information such as a sub-path that disambiguates a holder.

--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -2,7 +2,7 @@
 
 The Credential Issuance Protocol defines the endpoints and message types for requesting [=Verifiable Credentials=] from
 a [=Credential Issuer=]. The protocol is designed to handle use cases where credentials can automatically be issued and
-where a manual workflow is required.
+where a manual workflow is REQUIRED.
 
 ## Issuance Flow
 
@@ -12,11 +12,11 @@ issue a [=Verifiable Credential=]:
 ![Issuance Flow](specifications/issuance.flow.svg "Issuance Flow")
 
 1. The client sends a request to its [=Secure Token Service=] for a token including an access token. This could be a
-   [=Self-Issued ID Token=]. The API used to make this request is implementation specific. The client may include a set
+   [=Self-Issued ID Token=]. The API used to make this request is implementation specific. The client MAY include a set
    of scopes that define the [=Verifiable Credentials=] the client wants the [=Issuer Service=] to provide. This set of
-   scopes is determined out of band and may be derived from metadata the [=Credential Issuer=] has previously made
+   scopes is determined out of band and MAY be derived from metadata the [=Credential Issuer=] has previously made
    available to the client.
-2. The [=Secure Token Service=] responds with an access token, which may be included in the `token` claim of the
+2. The [=Secure Token Service=] responds with an access token, which MAY be included in the `token` claim of the
    [=Self-Issued ID Token=]. The access token can be used by the [=Issuer Service=] to write requested
    [=Verifiable Credentials=] to the client's [=Credential Service=].
 3. The client makes a request to the [=Issuer Service=] for one or more [=Verifiable Credentials=] and includes
@@ -79,7 +79,7 @@ requested [=Verifiable Credentials=] into the client's `Credential Service` as d
 by [[[#verifiable-presentation-protocol]]]. If the `token` claim is present, it MUST be used by the [=Issuer Service=].
 
 The bearer token MAY also be used by the [=Issuer Service=] to resolve [=Verifiable Presentations=] the client is
-required to hold for issuance of the requested [=Verifiable Credentials=].
+REQUIRED to hold for issuance of the requested [=Verifiable Credentials=].
 
 If the issuer supports a pre-authorization code flow, the client MUST use the `pre-authorized_code` claim in the
 Self-Issued ID Token to provide the pre-authorization code to the issuer.
@@ -97,7 +97,7 @@ Self-Issued ID Token to provide the pre-authorization code to the issuer.
 |              |                                                                                                         |
 |--------------|---------------------------------------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./resources/issuance/credential-request-message-schema.json)                              |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                             |
+| **REQUIRED** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                             |
 |              | - `type`: A string specifying the `CredentialRequestMessage` type.                                      |
 |              | - `holderPid`: A string corresponding to the request id on the Holder side.                             |
 |              | - `credentials`: an array of objects with an `id` property, each referencing a [[[#credentialobject]]]. |
@@ -146,11 +146,11 @@ exact error code is implementation-specific.
 |              |                                                                                                           |
 |--------------|-----------------------------------------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./resources/issuance/credential-message-schema.json)                                        |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                               |
+| **REQUIRED** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                               |
 |              | - `type`: A string specifying the `CredentialMessage` type.                                               |
 |              | - `issuerPid`: A string corresponding to the issuance id on the Issuer side.                              |
 |              | - `status`: A string stating whether the request was successful (`ISSUED`) or rejected (`REJECTED`).      |
-| **Optional** | - `credentials`: An array of [Credential Container](#credential-container) Json objects as defined bellow. |
+| **OPTIONAL** | - `credentials`: An array of [Credential Container](#credential-container) Json objects as defined bellow. |
 |              | - `holderPid`: A string corresponding to the issuance id on the Holder side.                              | 
 |              | - `rejectionReason`: a String containing additional information why a request was rejected. Can be `null`. |
 
@@ -169,7 +169,7 @@ The following example shows a rejected credential request JSON body:
 
 Note that the `status` applies to the entire request, i.e., a request is considered _rejected_ if at least one credential
 could not be issued.
-Allowed values for the `status` are `"ISSUED"` and `"REJECTED"`. The `rejectionReason` field is optional and should not
+Allowed values for the `status` are `"ISSUED"` and `"REJECTED"`. The `rejectionReason` field is OPTIONAL and SHOULD NOT
 disclose any confidential information.
 
 ### Credential Container
@@ -181,15 +181,15 @@ The  [Credential Container](#credential-container) object contains the following
 |              |                                                                                                                                                                                                                            |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./resources/issuance/credential-message-schema.json)                                                                                                                                                         |
-| **Required** | - `credentialType`: A single string specifying type of credential. See [VC DataModel 1.1](https://www.w3.org/TR/vc-data-model/#types) or [VC DataModel 2.0](https://www.w3.org/TR/vc-data-model-2.0/#types), respectively. |
+| **REQUIRED** | - `credentialType`: A single string specifying type of credential. See [VC DataModel 1.1](https://www.w3.org/TR/vc-data-model/#types) or [VC DataModel 2.0](https://www.w3.org/TR/vc-data-model-2.0/#types), respectively. |
 |              | - `payload`: A Json Literal ([[json-ld11]], sect. 4.2.2) containing a [=Verifiable Credential=] defined by [VC DataModel version of the selected profile](#profiles-of-the-decentralized-claims-protocol).                 |
 |              | - `format`:  a JSON string that describes the format of the credential to be issued.                                                                                                                                       |
 
 ## Credential Offer API
 
-Some scenarios involve the [=Credential Issuer=] making an initial offer. For example, an out-of-band process may result
+Some scenarios involve the [=Credential Issuer=] making an initial offer. For example, an out-of-band process MAY result
 in
-a credential offer. Or, a [=Credential Issuer=] may start a key rotation process which requires
+a credential offer. Or, a [=Credential Issuer=] MAY start a key rotation process which REQUIRED
 a [=Verifiable Credential=] to be
 reissued. In this case, the [=Credential Issuer=] can proactively prompt a [=Holder=] to request a
 new [=Verifiable Credential=]
@@ -211,13 +211,13 @@ a [=Verifiable Credential=] offer.
 |              |                                                                                                              |
 |--------------|--------------------------------------------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./resources/issuance/credential-offer-message-schema.json)                                     |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                  |
+| **REQUIRED** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                  |
 |              | - `type`: A string specifying the `CredentialOfferMessage` type.                                             |
 |              | - `issuer`:  The [=Credential Issuer=] DID.                                                                  |
 |              | - `credentials`: A non-empty JSON array, where every entry is a JSON object of type [[[#credentialobject]]]. |
 
 If the entries in the `credentials` property are _sparse_, i.e., only contain an `id`, the values of all other properties
-of the [[[#credentialobject]]] must be taken from the `credentialsSupported` list returned from
+of the [[[#credentialobject]]] MUST be taken from the `credentialsSupported` list returned from
 the [[[#issuer-metadata-api]]]. When processing, the [=Credential Service=] MUST resolve this string value to the
 respective object.
 
@@ -233,15 +233,15 @@ The following is a non-normative example of a credential offer request:
 |              |                                                                                                                                                                                                                               |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./resources/issuance/credential-object-schema.json)                                                                                                                                                             |
-| **Required** | - `type`: A string specifying the `CredentialObject` type.                                                                                                                                                                    |
+| **REQUIRED** | - `type`: A string specifying the `CredentialObject` type.                                                                                                                                                                    |
 |              | - `id`: a string defining a unique, stable identifier for this `CredentialObject`                                                                                                                                             |
-| **Optional** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). As the `credentialObject` is usually embedded, its context is provided by the enveloping object.                                                  |
+| **OPTIONAL** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). As the `credentialObject` is usually embedded, its context is provided by the enveloping object.                                                  |
 |              | - `credentialType`: A single string specifying type of credential being offered.                                                                                                                                              |
 |              | - `bindingMethods`: An array of strings defining the key material that an issued credential is bound to.                                                                                                                      |
 |              | - `credentialSchema`: A URL pointing to the credential schema of the object in a VC's `credentialSubject` property.                                                                                                           |
 |              | - `profile`: An string containing the alias of the [profiles](#profiles-of-the-decentralized-claims-protocol), e.g. `"vc20-bssl/jwt"`.                                                                                        |
-|              | - `issuancePolicy`: A [presentation definition](https://identity.foundation/presentation-exchange/spec/v2.1.1/#presentation-definition) [[presentation-ex]] signifying the required [=Verifiable Presentation=] for issuance. |
-|              | - `offerReason`: A reason for the offer as a string. Valid values may include `reissue` and `proof-key-revocation`.                                                                                                           |
+|              | - `issuancePolicy`: A [presentation definition](https://identity.foundation/presentation-exchange/spec/v2.1.1/#presentation-definition) [[presentation-ex]] signifying the REQUIRED [=Verifiable Presentation=] for issuance. |
+|              | - `offerReason`: A reason for the offer as a string. Valid values MAY include `reissue` and `proof-key-revocation`.                                                                                                           |
 
 The following is a non-normative example of a `CredentialObject`:
 
@@ -267,10 +267,10 @@ supported by the [=Credential Issuer=].
 |              |                                                                             |
 |--------------|-----------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./resources/issuance/issuer-metadata-schema.json)             |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). |
+| **REQUIRED** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1). |
 |              | - `type`: A string specifying the `IssuerMetadata` type.                    |
 |              | - `issuer`: A string containing the [=Credential Issuer=] DID.              |
-| **Optional** | - `credentialsSupported`: A JSON array of [[[#credentialobject]]] elements. |
+| **OPTIONAL** | - `credentialsSupported`: A JSON array of [[[#credentialobject]]] elements. |
 
 The following is a non-normative example of a `IssuerMetadata` response object:
 
@@ -279,7 +279,7 @@ The following is a non-normative example of a `IssuerMetadata` response object:
     </pre>
 </aside>  
 
-Every `CredentialObject` in the `credentialsSupported` array MUST contain all optional properties defined
+Every `CredentialObject` in the `credentialsSupported` array MUST contain all OPTIONAL properties defined
 in [[[#credentialobject]]].
 
 ## Credential Request Status API
@@ -294,7 +294,7 @@ The Credential Request Status API defines the REQUIRED [=Issuer Service=] endpoi
 | **URL Path**    | `/requests/<request id>`  where the request id corresponds to the ID identified by the location header returned for a [[[#credential-request-message]]] |
 | **Response**    | [[[#credentialstatus]]] `HTTP 200`                                                                                                                      |     
 
-The [=Issuer Service=] MUST implement access control such that only the client that made the request may access a
+The [=Issuer Service=] MUST implement access control such that only the client that made the request MAY access a
 particular request status. A [=Self-Issued ID Token=] MUST be submitted in the HTTP `Authorization` header prefixed
 with `Bearer` of the request.
 
@@ -303,7 +303,7 @@ with `Bearer` of the request.
 |              |                                                                              |
 |--------------|------------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./resources/issuance/credential-status-schema.json)            |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).  |
+| **REQUIRED** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).  |
 |              | - `type`: A string specifying the `CredentialStatus` type.                   |
 |              | - `issuerPid`: A string corresponding to the issuance id on the Issuer side. |
 |              | - `holderPid`: A string corresponding to the issuance id on the Holder side. |
@@ -323,33 +323,33 @@ create [=Verifiable Credential=] proofs.
 
 ### Key rotation
 
-Key rotation may be supported in the following way:
+Key rotation MAY be supported in the following way:
 
 1. After a defined `cryptoperiod`, a rotation is initiated, a new key pair is generated and the public key is added
    to a `verificationMethod` in the [=Credential Issuer=] DID document. The new private key is used to sign newly
    issued [=Verifiable Credential=] proofs.
 2. The old private key is decommissioned (archived or destroyed). However, the `verificationMethod` in
-   the [=Credential Issuer=] DID document are retained so existing issued [=Verifiable Credentials=] may be verified.
-3. At some point before existing [=Verifiable Credentials=] are set to expire, an [=Credential Issuer=] may make
+   the [=Credential Issuer=] DID document are retained so existing issued [=Verifiable Credentials=] MAY be verified.
+3. At some point before existing [=Verifiable Credentials=] are set to expire, an [=Credential Issuer=] MAY make
    credential offers for new [=Verifiable Credentials=] to [=Holders=] with the `offerReason = reissue` property.
 4. After a defined period, the rotated key's `verificationMethod` will be removed from the [=Credential Issuer=] DID
-   document. This period must at least extend to the expiration date of the last issued credential. At this point, any
+   document. This period MUST at least extend to the expiration date of the last issued credential. At this point, any
    existing [=Verifiable Credentials=] with proofs signed by the old (now rotated) key will become invalid.
 
 Implementors following this sequence SHOULD set the `expirationDate`/`validUntil` property of
 issued [=Verifiable Credentials=] to less than the rotation period of the keys used to sign their proofs. Rotated keys
-SHOULD not be decommissioned until all credentials, that were signed with it, have expired.
+SHOULD NOT be decommissioned until all credentials, that were signed with it, have expired.
 
 ### Key revocation
 
-Key revocation may be supported in the following way:
+Key revocation MAY be supported in the following way:
 
 1. After revocation is initiated, a new key pair is generated and the public key is added to a `verificationMethod` in
    the [=Credential Issuer=] DID document. The new private key is used to sign newly issued [=Verifiable Credential=]
    proofs.
 2. The old private key is decommissioned (archived or destroyed) and the `verificationMethod` in
    the [=Credential Issuer=] DID document is removed.
-3. The [=Credential Issuer=] may make credential offers for new [=Verifiable Credentials=] to [=Holders=] with the
+3. The [=Credential Issuer=] MAY make credential offers for new [=Verifiable Credentials=] to [=Holders=] with the
    `offerReason = proof-key-revocation` property.
 
 Upon revocation of a key pair, all credentials that were issued and proofed with that key immediately become invalid.

--- a/specifications/dataspace.ecosystem.md
+++ b/specifications/dataspace.ecosystem.md
@@ -6,7 +6,7 @@ adheres to the model defined by the Dataspace Protocol [[dsp-base]]:
 - A <dfn>Dataspace</dfn> is a policy-based data sharing context between two or more entities.
 - The <dfn>Dataspace Governance Authority</dfn> is responsible for operational management of a [=dataspace=],
   including [=participant=] registration and designation of trust credential issuers.
-- A <dfn>Participant</dfn> is a member of the [=dataspace=]. Members may take on different roles, which are attested to
+- A <dfn>Participant</dfn> is a member of the [=dataspace=]. Members MAY take on different roles, which are attested to
   by verifiable credentials.
 - A <dfn>Participant Agent</dfn> performs tasks such as publishing a catalog or engaging in data transfer. Note that a
   participant agent is a logical construct and does not necessarily correspond to a single runtime process.
@@ -33,9 +33,9 @@ The registration system is run by the [=Dataspace Governance Authority=] and is 
 
 ### Participant Agent Systems
 
-[=Participants=] will run one or more agent systems that interact in the dataspace. These systems may offer data
-catalogs, perform data transfers, or provide application functionality. A [=participant=] may run the following
-identity-related agents. Note that this is a logical description and may not represent an actual deployment topology.
+[=Participants=] will run one or more agent systems that interact in the dataspace. These systems MAY offer data
+catalogs, perform data transfers, or provide application functionality. A [=participant=] MAY run the following
+identity-related agents. Note that this is a logical description and MAY not represent an actual deployment topology.
 
 <dfn data-lt="sts | Secure Token Service">Security Token Service (STS).</dfn>
 
@@ -56,7 +56,7 @@ The DIDS creates, signs, and publishes DID documents.
 <dfn data-lt="is | Issuer Service">Issuer Service (IS)</dfn>
 
 The Issuer Service is run by a trust anchor and manages the lifecycle of [=Verifiable Credentials=] in a dataspace. A
-dataspace may contain multiple Issuer Services run by different trust anchors. The Issuer Service:
+dataspace MAY contain multiple Issuer Services run by different trust anchors. The Issuer Service:
 
 - Issues  [=Verifiable Credentials=] for dataspace [=participants=].
 - Manages revocation lists for  [=Verifiable Credentials=] types it issues based

--- a/specifications/dcp.profiles.md
+++ b/specifications/dcp.profiles.md
@@ -32,13 +32,13 @@ contains credentials of the same data model and proof mechanism.
 
 This non-normative section is intended to provide guidance to authors who want to define their own profile definition.
 
-At a minimum, the following profile aspects must be defined:
+At a minimum, the following profile aspects MUST be defined:
 
 - Verifiable Credential Data Model.
 - Revocation System. Specifies how the validity and expiration of Verifiable Credentials is checked.
 - Proof stack. Specifies how data integrity of the VC is to be provided.
 
-In addition, the profile may be further constrained, for example, by limiting the number of acceptable cryptographic 
+In addition, the profile MAY be further constrained, for example, by limiting the number of acceptable cryptographic 
 algorithms.
 
-If possible, a single credential format should be used when defining a profile.
+If possible, a single credential format SHOULD be used when defining a profile.

--- a/specifications/trust.model.md
+++ b/specifications/trust.model.md
@@ -19,7 +19,7 @@ The Issuer-Holder-Verifier model is mapped to the following architecture in this
 
 - Identity and claims information is exchanged between a [=Holder=] and a [=Verifier=] in the context of Dataspace
   Protocol message interactions [[dsp-base]]. These messages will contain metadata such as Offers and Agreements that
-  determine the [=Verifiable Credentials=] a [=Holder=] must present to a [=Verifier=].
+  determine the [=Verifiable Credentials=] a [=Holder=] MUST present to a [=Verifier=].
 - The [=Issuer Service=] issues credentials to a [=Holder=]'s [=Credential Service=] using the protocol defined in
   Section [[[#credential-issuance-protocol]]]. As part of this process, the [=Issuer Service=] will verify
   the [=Holder=]'s identifier using the [=Verifiable Data Registry=]. Since [=DID=]s are mandatory in this
@@ -28,7 +28,7 @@ The Issuer-Holder-Verifier model is mapped to the following architecture in this
   The [=Participant Agent=] engages in dataspace communications with the [=Verifier=] agent [[dsp-base]]. As part of
   these interactions, the [=Participant Agent=] will include a Self-Issued ID Token as defined in
   Section [[[#self-issued-id-tokens]]]. This token will be obtained from the [=STS=] controlled by the [=Holder=].
-  **Note that the [=STS=] is an internal system and therefore out of scope for the current specification. It may be a
+  **Note that the [=STS=] is an internal system and therefore out of scope for the current specification. It MAY be a
   standalone service or part of the [=Participant Agent=] or [=Credential Service=].** The Self-Issued ID Token will
   contain an access token bound to the [=Verifier=] that will be used to request a [=Verifiable Presentation=].
   The [=Holder=]'s [=Credential Service=] will verify the access token with the [=STS=].
@@ -51,13 +51,13 @@ defined in this specification establish consent in the following way:
 ![alt text 3](specifications/consent-model.svg "Consent in the Decentralized Claims Protocol")
 
 Consent is handled by first mapping Dataspace Protocol Offer and Agreement policies [[dsp-base]] to a set of
-required [=Verifiable Credentials=]. The exact mappings are dataspace-specific as policies
+REQUIRED [=Verifiable Credentials=]. The exact mappings are dataspace-specific as policies
 and [=Verifiable Credentials=] are typically defined for a particular domain. The expectation is that these mappings are
 made available by the [=Dataspace Governance Authority=] to [=Participant Agents=] via
 the [=Verifiable Data Registry=]. [=Verifiable Credential=] mapping is done by both the [=Holder=]
 and [=Verifier=] [=Participant Agent=] when a Dataspace Protocol message is sent and received.
 
-When sending a Dataspace Protocol message, the [=Holder=]'s [=Participant Agent=] will determine the required
+When sending a Dataspace Protocol message, the [=Holder=]'s [=Participant Agent=] will determine the REQUIRED
 [=Verifiable Credentials=] and issue a Self-Issued ID Token request to the [=STS=], including the list of credentials to
 allow the [=Verifier=] to access via the [=Credential Service=]. The returned Self-Issued ID token will contain an
 access token bound to the [=Verifier=] as described above. This access token serves as a verifiable mechanism
@@ -66,7 +66,7 @@ the [=Credential Service=] uses to determine consent and release credentials to 
 The [=Verifier=] establishes consent by performing the same mapping from metadata to a set
 of [=Verifiable Credentials=] during the initial Dataspace Protocol request. At that point,
 the [=Verifier=] [=Participant Agent=] can query the [=Credential Service=] for a [=Verifiable Presentation=]. If it
-matches the required credentials, the [=Verifier=] can consent and grant access to the associated protected resources.
+matches the REQUIRED credentials, the [=Verifier=] can consent and grant access to the associated protected resources.
 
 ## Trust Relationships
 
@@ -77,7 +77,7 @@ key aspects of those trust relationships.
 
 All entities expect:
 
-- The [=Verifiable Data Registry=] to be tamper-evident and correctly reflect data controlled by all entities. This may
+- The [=Verifiable Data Registry=] to be tamper-evident and correctly reflect data controlled by all entities. This MAY
   be done through the use of cryptographic resources.
 - All [=Verifiable Credentials=] and [=Verifiable Presentations=] to be tamper-proof and support revocation.
 - Dataspace Protocol interactions and those defined in this specification to be secure and use Transport Level
@@ -95,9 +95,9 @@ The [=Issuer=] expects:
 The [=Holder=] expects:
 
 - The [=Dataspace Governance Authority=] to provide a secure list of trusted [=Issuer=] [=DID=]s. How this list is provided is out
-  of scope of the current specification but may be part of the [=Verifiable Data Registry=].
+  of scope of the current specification but MAY be part of the [=Verifiable Data Registry=].
 - The [=Dataspace Governance Authority=] to provide a secure list of participant [=DIDs=]. How this list is provided is out
-  of scope of the current specification but may be part of the [=Verifiable Data Registry=].
+  of scope of the current specification but MAY be part of the [=Verifiable Data Registry=].
 - The [=Credential Service=] to maintain integrity and not release data to unauthorized parties.
 - The [=Issuer=] to issue credentials correctly, including binding them to the holder in a tamper-proof way, and
   maintaining credential integrity.
@@ -108,7 +108,7 @@ The [=Holder=] expects:
 The [=Verifier=] expects:
 
 - The [=Dataspace Governance Authority=] to provide a secure list of trusted [=Issuer=] [=DID=]s. How this list is provided is out
-  of scope of the current specification but may be part of the [=Verifiable Data Registry=]. [=Verifiers=] can
+  of scope of the current specification but MAY be part of the [=Verifiable Data Registry=]. [=Verifiers=] can
   recognize several [=Dataspace Governance Authorities=].
 
 - The [=Issuer=] to issue credentials correctly, including binding them to the holder in a tamper-proof way, and

--- a/specifications/verifiable.presentation.protocol.md
+++ b/specifications/verifiable.presentation.protocol.md
@@ -22,11 +22,11 @@ The following sequence diagram depicts a non-normative flow where a client inter
 ![Presentation Flow](specifications/auth.flow.svg "Presentation Flow")
 
 1. The client sends a request to its [=Secure Token Service=] for a token including an access token. This could be a
-   [=Self-Issued ID Token=]. The API used to make this request is implementation specific. The client may include a set
+   [=Self-Issued ID Token=]. The API used to make this request is implementation specific. The client MAY include a set
    of scopes that define the [=Verifiable Credentials=] the client wants the [=Verifier=] to have access to. This set of
-   scopes is determined out of band and may be derived from metadata the [=verifier=] has previously made available to
+   scopes is determined out of band and MAY be derived from metadata the [=verifier=] has previously made available to
    the client.
-2. The [=Secure Token Service=] responds with an access token, which may be included in the `token` claim of the
+2. The [=Secure Token Service=] responds with an access token, which MAY be included in the `token` claim of the
    [=Self-Issued ID Token=]. The access token can be used by the verifier to request [=Verifiable Credentials=] from the
    client's [=Credential Service=].
 3. The client makes a request to the [=Verifier=] for a protected resource and includes a [=Self-Issued ID Token=]
@@ -67,9 +67,9 @@ the [=Credential Service=]. The following is a non-normative example of a `Crede
 
 ## Credential Service Security
 
-As described in the previous presentation flow, a [=Credential Service=] may require an access token when processing a
+As described in the previous presentation flow, a [=Credential Service=] MAY REQUIRE an access token when processing a
 request from a [=Verifier=]. The format of the access token is not defined. How access control is defined in
-a [=Credential Service=] is implementation-specific. For example, implementations may provide the ability to selectively
+a [=Credential Service=] is implementation-specific. For example, implementations MAY provide the ability to selectively
 restrict access to resources.
 
 ### Submitting an Access Token
@@ -100,9 +100,9 @@ exact error code is implementation-specific.
 |              |                                                                                                            |
 |--------------|------------------------------------------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./resources/presentation/presentation-query-message-schema.json)                             |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                                 |
+| **REQUIRED** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1)                                 |
 |              | - `type`: A string specifying the `PresentationQueryMessage` type.                                         |
-| **Optional** | - `scope`: A non-empty array of scopes corresponding to Section [[[#scopes]]].                             |
+| **OPTIONAL** | - `scope`: A non-empty array of scopes corresponding to Section [[[#scopes]]].                             |
 |              | - `presentationDefinition`: A non-empty, valid `Presentation Definition` according to [[presentation-ex]]. |
 
 A `PresentationQueryMessage` MUST contain either a `presentationDefinition` or a `scope` parameter. If both parameters
@@ -133,7 +133,7 @@ by the definition.
 
 Implementations MAY support requesting presentation of [=Verifiable Credentials=] using a set of scope values.
 A scope is an alias for a well-defined Presentation Definition. The specific scope value and the
-mapping between it and the respective Presentation Definition are out of the scope of this specification. The array must 
+mapping between it and the respective Presentation Definition are out of the scope of this specification. The array MUST 
 contain at least one value. If the array is empty, the [=Credential Service=] MUST return `HTTP 4xx`.
 
 A scope is a string value in the form:
@@ -149,7 +149,7 @@ example:
 
 `org.eclipse.dspace.dcp.vc.type:Member`
 
-denotes read-only access to the VC type `Member` and may be used to request a VC or VP.
+denotes read-only access to the VC type `Member` and MAY be used to request a VC or VP.
 
 ##### The `org.eclipse.dspace.dcp.vc.id` Alias
 
@@ -158,7 +158,7 @@ credential by id. For example:
 
 `org.eclipse.dspace.dcp.vc.id:8247b87d-8d72-47e1-8128-9ce47e3d829d`
 
-denotes read-only access to the VC identified by `8247b87d-8d72-47e1-8128-9ce47e3d829d` and may be used to request a
+denotes read-only access to the VC identified by `8247b87d-8d72-47e1-8128-9ce47e3d829d` and MAY be used to request a
 [=Verifiable Credential=].
 
 ### Presentation Response Message
@@ -166,10 +166,10 @@ denotes read-only access to the VC identified by `8247b87d-8d72-47e1-8128-9ce47e
 |              |                                                                                                                                                                                   |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./resources/presentation/presentation-response-message-schema.json)                                                                                                 |
-| **Required** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                                                                                       |
+| **REQUIRED** | - `@context`: Specifies a valid Json-Ld context ([[json-ld11]], sect. 3.1).                                                                                                       |
 |              | - `type`: A string specifying the `PresentationResponseMessage` type.                                                                                                             |
-|              | - `presentation`: An array of [=Verifiable Presentations=]. The [=Verifiable Presentations=] may be strings, JSON objects, or a combination of both depending on the format.</br> |
-| **Optional** | - `presentationSubmission`: A valid `Presentation Submission` according to [[presentation-ex]].                                                                                   |
+|              | - `presentation`: An array of [=Verifiable Presentations=]. The [=Verifiable Presentations=] MAY be strings, JSON objects, or a combination of both depending on the format.</br> |
+| **OPTIONAL** | - `presentationSubmission`: A valid `Presentation Submission` according to [[presentation-ex]].                                                                                   |
 
 A `PresentationResponseMessage` SHOULD only include valid (non-expired, non-revoked, non-suspended) credentials.
 The following are non-normative examples of the JSON response body:


### PR DESCRIPTION
* fixing lower case keywords to upper case

## WHAT

_Briefly describe what your PR changes, which features it adds/modifies._

Closes #250 

## How was the issue fixed?

_Briefly state why the change was necessary._

## More context

_List other areas that have changed but are not necessarily linked to the main feature. This could be naming changes,
bugs that were encountered and were fixed inline, etc._